### PR TITLE
Complete Client Detail Screen with Management Tabs

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -65,6 +65,8 @@ kotlin {
             implementation(libs.androidx.navigation.compose)
             // Serialization (for type-safe navigation routes)
             implementation(libs.kotlinx.serialization.json)
+            // DateTime (multiplatform time)
+            implementation(libs.kotlinx.datetime)
             // Koin
             implementation(project.dependencies.platform(libs.koin.bom))
             implementation(libs.koin.core)

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -140,4 +140,174 @@
     <string name="error_create_user_failed">Error al crear el usuario. Por favor, inténtalo de nuevo.</string>
     <string name="error_update_user_failed">Error al actualizar el usuario. Por favor, inténtalo de nuevo.</string>
     <string name="error_delete_user_failed">Error al eliminar el usuario. Por favor, inténtalo de nuevo.</string>
+
+    <!-- Greenhouses Tab -->
+    <string name="greenhouses_title">Invernaderos del Cliente</string>
+    <string name="greenhouses_subtitle">Gestiona los invernaderos de este cliente.</string>
+    <string name="new_greenhouse">Nuevo Invernadero</string>
+    <string name="greenhouses_empty">No se encontraron invernaderos para este cliente.</string>
+
+    <!-- Greenhouse Table Headers -->
+    <string name="header_description">DESCRIPCIÓN</string>
+
+    <!-- Greenhouse Dialogs -->
+    <string name="dialog_new_greenhouse_title">Añadir Nuevo Invernadero</string>
+    <string name="dialog_new_greenhouse_subtitle">Añade un invernadero a este cliente</string>
+    <string name="button_create_greenhouse">Añadir Invernadero</string>
+    <string name="dialog_edit_greenhouse_title">Editar Invernadero</string>
+    <string name="dialog_edit_greenhouse_subtitle">Actualizar información del invernadero</string>
+    <string name="field_description">Descripción</string>
+    <string name="field_status">Estado</string>
+
+    <!-- Greenhouse Errors -->
+    <string name="error_create_greenhouse_failed">Error al crear el invernadero. Por favor, inténtalo de nuevo.</string>
+    <string name="error_update_greenhouse_failed">Error al actualizar el invernadero. Por favor, inténtalo de nuevo.</string>
+    <string name="error_delete_greenhouse_failed">Error al eliminar el invernadero. Por favor, inténtalo de nuevo.</string>
+
+    <!-- Delete Greenhouse Confirmation -->
+    <string name="dialog_delete_greenhouse_title">¿Eliminar Invernadero?</string>
+    <string name="dialog_delete_greenhouse_message">¿Estás seguro de que quieres eliminar "%1$s"? Esta acción no se puede deshacer.</string>
+
+    <!-- Sectors Tab -->
+    <string name="sectors_title">Sectores del Cliente</string>
+    <string name="sectors_subtitle">Gestiona los sectores de este cliente.</string>
+    <string name="new_sector">Nuevo Sector</string>
+    <string name="sectors_empty">No se encontraron sectores para este cliente.</string>
+
+    <!-- Sector Table Headers -->
+    <string name="header_greenhouse">INVERNADERO</string>
+    <string name="header_area">ÁREA</string>
+
+    <!-- Sector Dialogs -->
+    <string name="dialog_new_sector_title">Añadir Nuevo Sector</string>
+    <string name="dialog_new_sector_subtitle">Añade un sector a este cliente</string>
+    <string name="button_create_sector">Añadir Sector</string>
+    <string name="dialog_edit_sector_title">Editar Sector</string>
+    <string name="dialog_edit_sector_subtitle">Actualizar información del sector</string>
+    <string name="field_greenhouse">Invernadero</string>
+    <string name="field_area">Área (m²)</string>
+
+    <!-- Sector Validation Errors -->
+    <string name="error_greenhouse_required">Por favor, selecciona un invernadero</string>
+    <string name="error_area_required">El área es obligatoria</string>
+    <string name="error_area_invalid">Por favor, introduce un número válido</string>
+    <string name="error_area_positive">El área debe ser mayor que 0</string>
+
+    <!-- Sector Errors -->
+    <string name="error_create_sector_failed">Error al crear el sector. Por favor, inténtalo de nuevo.</string>
+    <string name="error_update_sector_failed">Error al actualizar el sector. Por favor, inténtalo de nuevo.</string>
+    <string name="error_delete_sector_failed">Error al eliminar el sector. Por favor, inténtalo de nuevo.</string>
+
+    <!-- Delete Sector Confirmation -->
+    <string name="dialog_delete_sector_title">¿Eliminar Sector?</string>
+    <string name="dialog_delete_sector_message">¿Estás seguro de que quieres eliminar "%1$s"? Esta acción no se puede deshacer.</string>
+
+    <!-- Devices Tab -->
+    <string name="devices_title">Dispositivos del Cliente</string>
+    <string name="devices_subtitle">Gestiona los dispositivos conectados de este cliente.</string>
+    <string name="new_device">Nuevo Dispositivo</string>
+    <string name="devices_empty">No se encontraron dispositivos para este cliente.</string>
+
+    <!-- Device Table Headers -->
+    <string name="header_type">TIPO</string>
+
+    <!-- Device Type and Status -->
+    <string name="device_type_sensor">Sensor</string>
+    <string name="device_type_actuator">Actuador</string>
+    <string name="device_status_online">En línea</string>
+    <string name="device_status_offline">Desconectado</string>
+    <string name="field_type">Tipo</string>
+
+    <!-- Device Dialogs -->
+    <string name="dialog_new_device_title">Añadir Nuevo Dispositivo</string>
+    <string name="dialog_new_device_subtitle">Añade un dispositivo a este cliente</string>
+    <string name="button_create_device">Añadir Dispositivo</string>
+    <string name="dialog_edit_device_title">Editar Dispositivo</string>
+    <string name="dialog_edit_device_subtitle">Actualizar información del dispositivo</string>
+
+    <!-- Device Errors -->
+    <string name="error_create_device_failed">Error al crear el dispositivo. Por favor, inténtalo de nuevo.</string>
+    <string name="error_update_device_failed">Error al actualizar el dispositivo. Por favor, inténtalo de nuevo.</string>
+    <string name="error_delete_device_failed">Error al eliminar el dispositivo. Por favor, inténtalo de nuevo.</string>
+
+    <!-- Delete Device Confirmation -->
+    <string name="dialog_delete_device_title">¿Eliminar Dispositivo?</string>
+    <string name="dialog_delete_device_message">¿Estás seguro de que quieres eliminar "%1$s"? Esta acción no se puede deshacer.</string>
+
+    <!-- Alerts Tab -->
+    <string name="alerts_title">Alertas del Cliente</string>
+    <string name="alerts_subtitle">Gestiona las alertas del sistema para este cliente.</string>
+    <string name="new_alert">Nueva Alerta</string>
+    <string name="alerts_empty">No se encontraron alertas para este cliente.</string>
+
+    <!-- Alert Table Headers -->
+    <string name="header_title">TÍTULO</string>
+    <string name="header_severity">SEVERIDAD</string>
+    <string name="header_date">FECHA</string>
+
+    <!-- Alert Severity -->
+    <string name="severity_low">Baja</string>
+    <string name="severity_medium">Media</string>
+    <string name="severity_high">Alta</string>
+    <string name="severity_critical">Crítica</string>
+
+    <!-- Alert Status -->
+    <string name="alert_status_unread">No leída</string>
+    <string name="alert_status_read">Leída</string>
+    <string name="alert_status_dismissed">Descartada</string>
+
+    <!-- Alert Dialogs -->
+    <string name="dialog_new_alert_title">Añadir Nueva Alerta</string>
+    <string name="dialog_new_alert_subtitle">Añade una alerta a este cliente</string>
+    <string name="button_create_alert">Añadir Alerta</string>
+    <string name="dialog_edit_alert_title">Editar Alerta</string>
+    <string name="dialog_edit_alert_subtitle">Actualizar información de la alerta</string>
+    <string name="field_title">Título</string>
+    <string name="field_severity">Severidad</string>
+
+    <!-- Alert Validation Errors -->
+    <string name="error_title_required">El título es obligatorio</string>
+
+    <!-- Alert Errors -->
+    <string name="error_create_alert_failed">Error al crear la alerta. Por favor, inténtalo de nuevo.</string>
+    <string name="error_update_alert_failed">Error al actualizar la alerta. Por favor, inténtalo de nuevo.</string>
+    <string name="error_delete_alert_failed">Error al eliminar la alerta. Por favor, inténtalo de nuevo.</string>
+
+    <!-- Delete Alert Confirmation -->
+    <string name="dialog_delete_alert_title">¿Eliminar Alerta?</string>
+    <string name="dialog_delete_alert_message">¿Estás seguro de que quieres eliminar "%1$s"? Esta acción no se puede deshacer.</string>
+
+    <!-- Settings Tab -->
+    <string name="settings_title">Ajustes del Cliente</string>
+    <string name="settings_subtitle">Gestiona los ajustes de configuración de este cliente.</string>
+    <string name="new_setting">Nuevo Ajuste</string>
+    <string name="settings_empty">No se encontraron ajustes para este cliente.</string>
+
+    <!-- Setting Table Headers -->
+    <string name="header_key">CLAVE</string>
+    <string name="header_value">VALOR</string>
+
+    <!-- Setting Dialogs -->
+    <string name="dialog_new_setting_title">Añadir Nuevo Ajuste</string>
+    <string name="dialog_new_setting_subtitle">Añade un ajuste de configuración a este cliente</string>
+    <string name="button_create_setting">Añadir Ajuste</string>
+    <string name="dialog_edit_setting_title">Editar Ajuste</string>
+    <string name="dialog_edit_setting_subtitle">Actualizar información del ajuste</string>
+    <string name="field_key">Clave</string>
+    <string name="field_value">Valor</string>
+
+    <!-- Setting Validation Errors -->
+    <string name="error_key_required">La clave es obligatoria</string>
+    <string name="error_key_min_length">La clave debe tener al menos 2 caracteres</string>
+    <string name="error_key_invalid">La clave debe empezar con una letra y contener solo letras, números y guiones bajos</string>
+    <string name="error_value_required">El valor es obligatorio</string>
+
+    <!-- Setting Errors -->
+    <string name="error_create_setting_failed">Error al crear el ajuste. Por favor, inténtalo de nuevo.</string>
+    <string name="error_update_setting_failed">Error al actualizar el ajuste. Por favor, inténtalo de nuevo.</string>
+    <string name="error_delete_setting_failed">Error al eliminar el ajuste. Por favor, inténtalo de nuevo.</string>
+
+    <!-- Delete Setting Confirmation -->
+    <string name="dialog_delete_setting_title">¿Eliminar Ajuste?</string>
+    <string name="dialog_delete_setting_message">¿Estás seguro de que quieres eliminar "%1$s"? Esta acción no se puede deshacer.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -140,4 +140,174 @@
     <string name="error_create_user_failed">Failed to create user. Please try again.</string>
     <string name="error_update_user_failed">Failed to update user. Please try again.</string>
     <string name="error_delete_user_failed">Failed to delete user. Please try again.</string>
+
+    <!-- Greenhouses Tab -->
+    <string name="greenhouses_title">Client Greenhouses</string>
+    <string name="greenhouses_subtitle">Manage greenhouses for this client.</string>
+    <string name="new_greenhouse">New Greenhouse</string>
+    <string name="greenhouses_empty">No greenhouses found for this client.</string>
+
+    <!-- Greenhouse Table Headers -->
+    <string name="header_description">DESCRIPTION</string>
+
+    <!-- Greenhouse Dialogs -->
+    <string name="dialog_new_greenhouse_title">Add New Greenhouse</string>
+    <string name="dialog_new_greenhouse_subtitle">Add a greenhouse to this client</string>
+    <string name="button_create_greenhouse">Add Greenhouse</string>
+    <string name="dialog_edit_greenhouse_title">Edit Greenhouse</string>
+    <string name="dialog_edit_greenhouse_subtitle">Update greenhouse information</string>
+    <string name="field_description">Description</string>
+    <string name="field_status">Status</string>
+
+    <!-- Greenhouse Errors -->
+    <string name="error_create_greenhouse_failed">Failed to create greenhouse. Please try again.</string>
+    <string name="error_update_greenhouse_failed">Failed to update greenhouse. Please try again.</string>
+    <string name="error_delete_greenhouse_failed">Failed to delete greenhouse. Please try again.</string>
+
+    <!-- Delete Greenhouse Confirmation -->
+    <string name="dialog_delete_greenhouse_title">Delete Greenhouse?</string>
+    <string name="dialog_delete_greenhouse_message">Are you sure you want to delete "%1$s"? This action cannot be undone.</string>
+
+    <!-- Sectors Tab -->
+    <string name="sectors_title">Client Sectors</string>
+    <string name="sectors_subtitle">Manage sectors for this client.</string>
+    <string name="new_sector">New Sector</string>
+    <string name="sectors_empty">No sectors found for this client.</string>
+
+    <!-- Sector Table Headers -->
+    <string name="header_greenhouse">GREENHOUSE</string>
+    <string name="header_area">AREA</string>
+
+    <!-- Sector Dialogs -->
+    <string name="dialog_new_sector_title">Add New Sector</string>
+    <string name="dialog_new_sector_subtitle">Add a sector to this client</string>
+    <string name="button_create_sector">Add Sector</string>
+    <string name="dialog_edit_sector_title">Edit Sector</string>
+    <string name="dialog_edit_sector_subtitle">Update sector information</string>
+    <string name="field_greenhouse">Greenhouse</string>
+    <string name="field_area">Area (m²)</string>
+
+    <!-- Sector Validation Errors -->
+    <string name="error_greenhouse_required">Please select a greenhouse</string>
+    <string name="error_area_required">Area is required</string>
+    <string name="error_area_invalid">Please enter a valid number</string>
+    <string name="error_area_positive">Area must be greater than 0</string>
+
+    <!-- Sector Errors -->
+    <string name="error_create_sector_failed">Failed to create sector. Please try again.</string>
+    <string name="error_update_sector_failed">Failed to update sector. Please try again.</string>
+    <string name="error_delete_sector_failed">Failed to delete sector. Please try again.</string>
+
+    <!-- Delete Sector Confirmation -->
+    <string name="dialog_delete_sector_title">Delete Sector?</string>
+    <string name="dialog_delete_sector_message">Are you sure you want to delete "%1$s"? This action cannot be undone.</string>
+
+    <!-- Devices Tab -->
+    <string name="devices_title">Client Devices</string>
+    <string name="devices_subtitle">Manage connected devices for this client.</string>
+    <string name="new_device">New Device</string>
+    <string name="devices_empty">No devices found for this client.</string>
+
+    <!-- Device Table Headers -->
+    <string name="header_type">TYPE</string>
+
+    <!-- Device Type and Status -->
+    <string name="device_type_sensor">Sensor</string>
+    <string name="device_type_actuator">Actuator</string>
+    <string name="device_status_online">Online</string>
+    <string name="device_status_offline">Offline</string>
+    <string name="field_type">Type</string>
+
+    <!-- Device Dialogs -->
+    <string name="dialog_new_device_title">Add New Device</string>
+    <string name="dialog_new_device_subtitle">Add a device to this client</string>
+    <string name="button_create_device">Add Device</string>
+    <string name="dialog_edit_device_title">Edit Device</string>
+    <string name="dialog_edit_device_subtitle">Update device information</string>
+
+    <!-- Device Errors -->
+    <string name="error_create_device_failed">Failed to create device. Please try again.</string>
+    <string name="error_update_device_failed">Failed to update device. Please try again.</string>
+    <string name="error_delete_device_failed">Failed to delete device. Please try again.</string>
+
+    <!-- Delete Device Confirmation -->
+    <string name="dialog_delete_device_title">Delete Device?</string>
+    <string name="dialog_delete_device_message">Are you sure you want to delete "%1$s"? This action cannot be undone.</string>
+
+    <!-- Alerts Tab -->
+    <string name="alerts_title">Client Alerts</string>
+    <string name="alerts_subtitle">Manage system alerts for this client.</string>
+    <string name="new_alert">New Alert</string>
+    <string name="alerts_empty">No alerts found for this client.</string>
+
+    <!-- Alert Table Headers -->
+    <string name="header_title">TITLE</string>
+    <string name="header_severity">SEVERITY</string>
+    <string name="header_date">DATE</string>
+
+    <!-- Alert Severity -->
+    <string name="severity_low">Low</string>
+    <string name="severity_medium">Medium</string>
+    <string name="severity_high">High</string>
+    <string name="severity_critical">Critical</string>
+
+    <!-- Alert Status -->
+    <string name="alert_status_unread">Unread</string>
+    <string name="alert_status_read">Read</string>
+    <string name="alert_status_dismissed">Dismissed</string>
+
+    <!-- Alert Dialogs -->
+    <string name="dialog_new_alert_title">Add New Alert</string>
+    <string name="dialog_new_alert_subtitle">Add an alert to this client</string>
+    <string name="button_create_alert">Add Alert</string>
+    <string name="dialog_edit_alert_title">Edit Alert</string>
+    <string name="dialog_edit_alert_subtitle">Update alert information</string>
+    <string name="field_title">Title</string>
+    <string name="field_severity">Severity</string>
+
+    <!-- Alert Validation Errors -->
+    <string name="error_title_required">Title is required</string>
+
+    <!-- Alert Errors -->
+    <string name="error_create_alert_failed">Failed to create alert. Please try again.</string>
+    <string name="error_update_alert_failed">Failed to update alert. Please try again.</string>
+    <string name="error_delete_alert_failed">Failed to delete alert. Please try again.</string>
+
+    <!-- Delete Alert Confirmation -->
+    <string name="dialog_delete_alert_title">Delete Alert?</string>
+    <string name="dialog_delete_alert_message">Are you sure you want to delete "%1$s"? This action cannot be undone.</string>
+
+    <!-- Settings Tab -->
+    <string name="settings_title">Client Settings</string>
+    <string name="settings_subtitle">Manage configuration settings for this client.</string>
+    <string name="new_setting">New Setting</string>
+    <string name="settings_empty">No settings found for this client.</string>
+
+    <!-- Setting Table Headers -->
+    <string name="header_key">KEY</string>
+    <string name="header_value">VALUE</string>
+
+    <!-- Setting Dialogs -->
+    <string name="dialog_new_setting_title">Add New Setting</string>
+    <string name="dialog_new_setting_subtitle">Add a configuration setting to this client</string>
+    <string name="button_create_setting">Add Setting</string>
+    <string name="dialog_edit_setting_title">Edit Setting</string>
+    <string name="dialog_edit_setting_subtitle">Update setting information</string>
+    <string name="field_key">Key</string>
+    <string name="field_value">Value</string>
+
+    <!-- Setting Validation Errors -->
+    <string name="error_key_required">Key is required</string>
+    <string name="error_key_min_length">Key must be at least 2 characters</string>
+    <string name="error_key_invalid">Key must start with a letter and contain only letters, numbers, and underscores</string>
+    <string name="error_value_required">Value is required</string>
+
+    <!-- Setting Errors -->
+    <string name="error_create_setting_failed">Failed to create setting. Please try again.</string>
+    <string name="error_update_setting_failed">Failed to update setting. Please try again.</string>
+    <string name="error_delete_setting_failed">Failed to delete setting. Please try again.</string>
+
+    <!-- Delete Setting Confirmation -->
+    <string name="dialog_delete_setting_title">Delete Setting?</string>
+    <string name="dialog_delete_setting_message">Are you sure you want to delete "%1$s"? This action cannot be undone.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/AlertFormData.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/AlertFormData.kt
@@ -1,0 +1,36 @@
+package com.apptolast.greenhouse.admin.data.model
+
+/**
+ * Form data for creating or editing an alert.
+ */
+data class AlertFormData(
+    val title: String = "",
+    val severity: AlertSeverity = AlertSeverity.LOW,
+    val status: AlertStatus = AlertStatus.UNREAD
+) {
+    /**
+     * Validation errors for alert form fields.
+     */
+    data class ValidationErrors(
+        val title: String? = null
+    ) {
+        val hasErrors: Boolean
+            get() = title != null
+    }
+
+    /**
+     * Validates the form data and returns any errors.
+     */
+    fun validate(): ValidationErrors {
+        return ValidationErrors(
+            title = when {
+                title.isBlank() -> "error_title_required"
+                title.length < 2 -> "error_name_min_length"
+                else -> null
+            }
+        )
+    }
+
+    val isValid: Boolean
+        get() = !validate().hasErrors
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/AlertModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/AlertModels.kt
@@ -1,0 +1,43 @@
+package com.apptolast.greenhouse.admin.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an alert in the system.
+ */
+@Serializable
+data class Alert(
+    val id: String,
+    val title: String,
+    val severity: AlertSeverity,
+    val status: AlertStatus,
+    val createdAt: Long,
+    val clientId: String
+) {
+    /**
+     * Returns the initials (first two letters of title) for avatar display.
+     */
+    val initials: String
+        get() = title.take(2).uppercase()
+}
+
+/**
+ * Severity levels for alerts.
+ */
+@Serializable
+enum class AlertSeverity {
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL
+}
+
+/**
+ * Status options for alerts.
+ */
+@Serializable
+enum class AlertStatus {
+    UNREAD,
+    READ,
+    DISMISSED
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/DeviceFormData.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/DeviceFormData.kt
@@ -1,0 +1,36 @@
+package com.apptolast.greenhouse.admin.data.model
+
+/**
+ * Form data for creating or editing a device.
+ * Manages form state and validation.
+ */
+data class DeviceFormData(
+    val name: String = "",
+    val type: DeviceType = DeviceType.SENSOR,
+    val status: DeviceStatus = DeviceStatus.ONLINE
+) {
+    /**
+     * Validation errors for each field.
+     */
+    data class ValidationErrors(
+        val name: String? = null
+    ) {
+        val hasErrors: Boolean
+            get() = name != null
+    }
+
+    /**
+     * Validates the form and returns any errors.
+     */
+    fun validate(): ValidationErrors {
+        return ValidationErrors(
+            name = if (name.length < 2) "error_name_min_length" else null
+        )
+    }
+
+    /**
+     * Returns true if all required fields are valid.
+     */
+    val isValid: Boolean
+        get() = name.length >= 2
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/DeviceModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/DeviceModels.kt
@@ -1,0 +1,42 @@
+package com.apptolast.greenhouse.admin.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a device connected to the greenhouse system.
+ */
+@Serializable
+data class Device(
+    val id: String,
+    val name: String,
+    val type: DeviceType,
+    val status: DeviceStatus,
+    val clientId: String
+) {
+    /**
+     * Returns the initials of the device name for display in avatars.
+     */
+    val initials: String
+        get() = name.split(" ")
+            .take(2)
+            .mapNotNull { it.firstOrNull()?.uppercaseChar() }
+            .joinToString("")
+}
+
+/**
+ * Type of device.
+ */
+@Serializable
+enum class DeviceType {
+    SENSOR,
+    ACTUATOR
+}
+
+/**
+ * Status of device connection.
+ */
+@Serializable
+enum class DeviceStatus {
+    ONLINE,
+    OFFLINE
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/GreenhouseFormData.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/GreenhouseFormData.kt
@@ -1,0 +1,38 @@
+package com.apptolast.greenhouse.admin.data.model
+
+/**
+ * Form data for creating or editing a greenhouse.
+ * Manages form state and validation.
+ */
+data class GreenhouseFormData(
+    val name: String = "",
+    val description: String = "",
+    val status: GreenhouseStatus = GreenhouseStatus.ACTIVE
+) {
+    /**
+     * Validation errors for each field.
+     */
+    data class ValidationErrors(
+        val name: String? = null,
+        val description: String? = null
+    ) {
+        val hasErrors: Boolean
+            get() = name != null || description != null
+    }
+
+    /**
+     * Validates the form and returns any errors.
+     */
+    fun validate(): ValidationErrors {
+        return ValidationErrors(
+            name = if (name.length < 2) "error_name_min_length" else null,
+            description = null // Description is optional
+        )
+    }
+
+    /**
+     * Returns true if all required fields are valid.
+     */
+    val isValid: Boolean
+        get() = name.length >= 2
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/GreenhouseModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/GreenhouseModels.kt
@@ -1,0 +1,34 @@
+package com.apptolast.greenhouse.admin.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a greenhouse associated with a client.
+ * MVP structure with simplified fields.
+ */
+@Serializable
+data class Greenhouse(
+    val id: String,
+    val name: String,
+    val description: String,
+    val status: GreenhouseStatus,
+    val clientId: String
+) {
+    /**
+     * Returns the initials from the greenhouse name (max 2 letters).
+     */
+    val initials: String
+        get() = name.split(" ")
+            .take(2)
+            .mapNotNull { it.firstOrNull()?.uppercaseChar() }
+            .joinToString("")
+}
+
+/**
+ * Status of a greenhouse.
+ */
+@Serializable
+enum class GreenhouseStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/SectorFormData.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/SectorFormData.kt
@@ -1,0 +1,56 @@
+package com.apptolast.greenhouse.admin.data.model
+
+/**
+ * Form data for creating or editing a sector.
+ * Manages form state and validation.
+ */
+data class SectorFormData(
+    val name: String = "",
+    val greenhouseId: String = "",
+    val area: String = "" // String for text field input
+) {
+    /**
+     * Validation errors for each field.
+     */
+    data class ValidationErrors(
+        val name: String? = null,
+        val greenhouseId: String? = null,
+        val area: String? = null
+    ) {
+        val hasErrors: Boolean
+            get() = name != null || greenhouseId != null || area != null
+    }
+
+    /**
+     * Validates the form and returns any errors.
+     */
+    fun validate(): ValidationErrors {
+        return ValidationErrors(
+            name = if (name.length < 2) "error_name_min_length" else null,
+            greenhouseId = if (greenhouseId.isBlank()) "error_greenhouse_required" else null,
+            area = validateArea()
+        )
+    }
+
+    private fun validateArea(): String? {
+        if (area.isBlank()) return "error_area_required"
+        val areaValue = area.toDoubleOrNull()
+        return when {
+            areaValue == null -> "error_area_invalid"
+            areaValue <= 0 -> "error_area_positive"
+            else -> null
+        }
+    }
+
+    /**
+     * Returns the area as Double, or 0.0 if invalid.
+     */
+    val areaValue: Double
+        get() = area.toDoubleOrNull() ?: 0.0
+
+    /**
+     * Returns true if all required fields are valid.
+     */
+    val isValid: Boolean
+        get() = name.length >= 2 && greenhouseId.isNotBlank() && area.toDoubleOrNull()?.let { it > 0 } == true
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/SectorModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/SectorModels.kt
@@ -1,0 +1,32 @@
+package com.apptolast.greenhouse.admin.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a sector within a greenhouse.
+ * A sector is a subdivision of a greenhouse with a defined area.
+ */
+@Serializable
+data class Sector(
+    val id: String,
+    val name: String,
+    val greenhouseId: String,
+    val greenhouseName: String = "", // For display purposes
+    val area: Double, // In square meters (m²)
+    val clientId: String
+) {
+    /**
+     * Returns the initials of the sector name for display in avatars.
+     */
+    val initials: String
+        get() = name.split(" ")
+            .take(2)
+            .mapNotNull { it.firstOrNull()?.uppercaseChar() }
+            .joinToString("")
+
+    /**
+     * Returns the area formatted with unit.
+     */
+    val formattedArea: String
+        get() = "$area m²"
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/SettingFormData.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/SettingFormData.kt
@@ -1,0 +1,48 @@
+package com.apptolast.greenhouse.admin.data.model
+
+/**
+ * Form data class for creating/editing settings with validation.
+ */
+data class SettingFormData(
+    val key: String = "",
+    val value: String = "",
+    val description: String = ""
+) {
+    /**
+     * Validation errors container.
+     */
+    data class ValidationErrors(
+        val key: String? = null,
+        val value: String? = null
+    ) {
+        /**
+         * Returns true if there are any validation errors.
+         */
+        val hasErrors: Boolean
+            get() = key != null || value != null
+    }
+
+    /**
+     * Validates the form data and returns validation errors.
+     */
+    fun validate(): ValidationErrors {
+        return ValidationErrors(
+            key = when {
+                key.isBlank() -> "error_key_required"
+                key.length < 2 -> "error_key_min_length"
+                !key.matches(Regex("^[a-zA-Z][a-zA-Z0-9_]*$")) -> "error_key_invalid"
+                else -> null
+            },
+            value = when {
+                value.isBlank() -> "error_value_required"
+                else -> null
+            }
+        )
+    }
+
+    /**
+     * Returns true if the form data is valid.
+     */
+    val isValid: Boolean
+        get() = !validate().hasErrors
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/SettingModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/model/SettingModels.kt
@@ -1,0 +1,22 @@
+package com.apptolast.greenhouse.admin.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Domain model for Setting entity.
+ * Represents a client-specific configuration setting.
+ */
+@Serializable
+data class Setting(
+    val id: String,
+    val key: String,
+    val value: String,
+    val description: String,
+    val clientId: String
+) {
+    /**
+     * Returns the first two letters of the key (uppercase) for avatar display.
+     */
+    val initials: String
+        get() = key.take(2).uppercase()
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/AlertsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/AlertsRepositoryImpl.kt
@@ -1,0 +1,106 @@
+package com.apptolast.greenhouse.admin.data.repository
+
+import com.apptolast.greenhouse.admin.data.model.Alert
+import com.apptolast.greenhouse.admin.data.model.AlertSeverity
+import com.apptolast.greenhouse.admin.data.model.AlertStatus
+import com.apptolast.greenhouse.admin.domain.repository.AlertsRepository
+import kotlinx.coroutines.delay
+import kotlin.time.Clock
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Mock implementation of AlertsRepository.
+ * Provides hardcoded data for development. Replace with real API calls later.
+ */
+class AlertsRepositoryImpl : AlertsRepository {
+
+    private val mockAlerts = mutableListOf(
+        // Alerts for client "1" (Elena Rodriguez)
+        Alert(
+            id = "a1",
+            title = "Temperatura alta en Sector A",
+            severity = AlertSeverity.HIGH,
+            status = AlertStatus.UNREAD,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 3600000, // 1 hour ago
+            clientId = "1"
+        ),
+        Alert(
+            id = "a2",
+            title = "Humedad baja detectada",
+            severity = AlertSeverity.MEDIUM,
+            status = AlertStatus.READ,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 86400000, // 1 day ago
+            clientId = "1"
+        ),
+        Alert(
+            id = "a3",
+            title = "Mantenimiento programado",
+            severity = AlertSeverity.LOW,
+            status = AlertStatus.DISMISSED,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 172800000, // 2 days ago
+            clientId = "1"
+        ),
+        Alert(
+            id = "a4",
+            title = "Sensor CO2 desconectado",
+            severity = AlertSeverity.CRITICAL,
+            status = AlertStatus.UNREAD,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 1800000, // 30 minutes ago
+            clientId = "1"
+        ),
+        // Alerts for client "2" (Jean Pierre)
+        Alert(
+            id = "a5",
+            title = "Alerte temperature basse",
+            severity = AlertSeverity.MEDIUM,
+            status = AlertStatus.UNREAD,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 7200000, // 2 hours ago
+            clientId = "2"
+        ),
+        // Alerts for client "4" (Maria Muller)
+        Alert(
+            id = "a6",
+            title = "Bewaesserungssystem Fehler",
+            severity = AlertSeverity.HIGH,
+            status = AlertStatus.UNREAD,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 14400000, // 4 hours ago
+            clientId = "4"
+        )
+    )
+
+    override suspend fun getAlertsByClientId(clientId: String): Result<List<Alert>> = runCatching {
+        delay(400)
+        mockAlerts.filter { it.clientId == clientId }.sortedByDescending { it.createdAt }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun createAlert(alert: Alert): Result<Alert> = runCatching {
+        delay(600)
+        val newAlert = alert.copy(
+            id = Uuid.random().toString(),
+            createdAt = Clock.System.now().toEpochMilliseconds()
+        )
+        mockAlerts.add(newAlert)
+        newAlert
+    }
+
+    override suspend fun updateAlert(alert: Alert): Result<Alert> = runCatching {
+        delay(500)
+        val index = mockAlerts.indexOfFirst { it.id == alert.id }
+        if (index == -1) {
+            throw NoSuchElementException("Alert with id ${alert.id} not found")
+        }
+        mockAlerts[index] = alert
+        alert
+    }
+
+    override suspend fun deleteAlert(id: String): Result<Unit> = runCatching {
+        delay(400)
+        val index = mockAlerts.indexOfFirst { it.id == id }
+        if (index == -1) {
+            throw NoSuchElementException("Alert with id $id not found")
+        }
+        mockAlerts.removeAt(index)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/DevicesRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/DevicesRepositoryImpl.kt
@@ -1,0 +1,110 @@
+package com.apptolast.greenhouse.admin.data.repository
+
+import com.apptolast.greenhouse.admin.data.model.Device
+import com.apptolast.greenhouse.admin.data.model.DeviceStatus
+import com.apptolast.greenhouse.admin.data.model.DeviceType
+import com.apptolast.greenhouse.admin.domain.repository.DevicesRepository
+import kotlinx.coroutines.delay
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Mock implementation of DevicesRepository.
+ * Provides hardcoded data for development. Replace with real API calls later.
+ */
+class DevicesRepositoryImpl : DevicesRepository {
+
+    private val mockDevices = mutableListOf(
+        // Devices for client "1" (Elena Rodriguez)
+        Device(
+            id = "d1",
+            name = "Sensor Temperatura A1",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "1"
+        ),
+        Device(
+            id = "d2",
+            name = "Sensor Humedad A1",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "1"
+        ),
+        Device(
+            id = "d3",
+            name = "Valvula Riego Norte",
+            type = DeviceType.ACTUATOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "1"
+        ),
+        Device(
+            id = "d4",
+            name = "Sensor CO2 B2",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.OFFLINE,
+            clientId = "1"
+        ),
+        // Devices for client "2" (Jean Pierre)
+        Device(
+            id = "d5",
+            name = "Capteur Temperature",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "2"
+        ),
+        Device(
+            id = "d6",
+            name = "Vanne Irrigation",
+            type = DeviceType.ACTUATOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "2"
+        ),
+        // Devices for client "4" (Maria Muller)
+        Device(
+            id = "d7",
+            name = "Temperatursensor 1",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "4"
+        ),
+        Device(
+            id = "d8",
+            name = "Bewaesserungsventil",
+            type = DeviceType.ACTUATOR,
+            status = DeviceStatus.OFFLINE,
+            clientId = "4"
+        )
+    )
+
+    override suspend fun getDevicesByClientId(clientId: String): Result<List<Device>> = runCatching {
+        delay(400)
+        mockDevices.filter { it.clientId == clientId }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun createDevice(device: Device): Result<Device> = runCatching {
+        delay(600)
+        val newDevice = device.copy(id = Uuid.random().toString())
+        mockDevices.add(newDevice)
+        newDevice
+    }
+
+    override suspend fun updateDevice(device: Device): Result<Device> = runCatching {
+        delay(500)
+        val index = mockDevices.indexOfFirst { it.id == device.id }
+        if (index == -1) {
+            throw NoSuchElementException("Device with id ${device.id} not found")
+        }
+        mockDevices[index] = device
+        device
+    }
+
+    override suspend fun deleteDevice(id: String): Result<Unit> = runCatching {
+        delay(400)
+        val index = mockDevices.indexOfFirst { it.id == id }
+        if (index == -1) {
+            throw NoSuchElementException("Device with id $id not found")
+        }
+        mockDevices.removeAt(index)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/GreenhousesRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/GreenhousesRepositoryImpl.kt
@@ -1,0 +1,95 @@
+package com.apptolast.greenhouse.admin.data.repository
+
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
+import com.apptolast.greenhouse.admin.data.model.GreenhouseStatus
+import com.apptolast.greenhouse.admin.domain.repository.GreenhousesRepository
+import kotlinx.coroutines.delay
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Mock implementation of GreenhousesRepository.
+ * Provides hardcoded data for development. Replace with real API calls later.
+ */
+class GreenhousesRepositoryImpl : GreenhousesRepository {
+
+    private val mockGreenhouses = mutableListOf(
+        // Greenhouses for client "1" (Elena Rodriguez)
+        Greenhouse(
+            id = "gh1",
+            name = "Invernadero Principal",
+            description = "Producción de tomates y pimientos",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "1"
+        ),
+        Greenhouse(
+            id = "gh2",
+            name = "Invernadero Norte",
+            description = "Cultivo de lechugas hidropónicas",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "1"
+        ),
+        Greenhouse(
+            id = "gh3",
+            name = "Invernadero Experimental",
+            description = "Pruebas de nuevas variedades",
+            status = GreenhouseStatus.INACTIVE,
+            clientId = "1"
+        ),
+        // Greenhouses for client "2" (Jean Pierre)
+        Greenhouse(
+            id = "gh4",
+            name = "Serre Principale",
+            description = "Production biologique",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "2"
+        ),
+        // Greenhouses for client "4" (Maria Muller)
+        Greenhouse(
+            id = "gh5",
+            name = "Gewächshaus A",
+            description = "Gemüseanbau",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "4"
+        ),
+        Greenhouse(
+            id = "gh6",
+            name = "Gewächshaus B",
+            description = "Kräuterproduktion",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "4"
+        )
+    )
+
+    override suspend fun getGreenhousesByClientId(clientId: String): Result<List<Greenhouse>> = runCatching {
+        delay(400)
+        mockGreenhouses.filter { it.clientId == clientId }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun createGreenhouse(greenhouse: Greenhouse): Result<Greenhouse> = runCatching {
+        delay(600)
+        val newGreenhouse = greenhouse.copy(id = Uuid.random().toString())
+        mockGreenhouses.add(newGreenhouse)
+        newGreenhouse
+    }
+
+    override suspend fun updateGreenhouse(greenhouse: Greenhouse): Result<Greenhouse> = runCatching {
+        delay(500)
+        val index = mockGreenhouses.indexOfFirst { it.id == greenhouse.id }
+        if (index == -1) {
+            throw NoSuchElementException("Greenhouse with id ${greenhouse.id} not found")
+        }
+        mockGreenhouses[index] = greenhouse
+        greenhouse
+    }
+
+    override suspend fun deleteGreenhouse(id: String): Result<Unit> = runCatching {
+        delay(400)
+        val index = mockGreenhouses.indexOfFirst { it.id == id }
+        if (index == -1) {
+            throw NoSuchElementException("Greenhouse with id $id not found")
+        }
+        mockGreenhouses.removeAt(index)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/SectorsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/SectorsRepositoryImpl.kt
@@ -1,0 +1,108 @@
+package com.apptolast.greenhouse.admin.data.repository
+
+import com.apptolast.greenhouse.admin.data.model.Sector
+import com.apptolast.greenhouse.admin.domain.repository.SectorsRepository
+import kotlinx.coroutines.delay
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Mock implementation of SectorsRepository.
+ * Provides hardcoded data for development. Replace with real API calls later.
+ */
+class SectorsRepositoryImpl : SectorsRepository {
+
+    private val mockSectors = mutableListOf(
+        // Sectors for client "1" (Elena Rodriguez)
+        Sector(
+            id = "s1",
+            name = "Sector Norte A",
+            greenhouseId = "gh1",
+            greenhouseName = "Invernadero Principal",
+            area = 150.0,
+            clientId = "1"
+        ),
+        Sector(
+            id = "s2",
+            name = "Sector Norte B",
+            greenhouseId = "gh1",
+            greenhouseName = "Invernadero Principal",
+            area = 120.5,
+            clientId = "1"
+        ),
+        Sector(
+            id = "s3",
+            name = "Sector Sur",
+            greenhouseId = "gh1",
+            greenhouseName = "Invernadero Principal",
+            area = 200.0,
+            clientId = "1"
+        ),
+        Sector(
+            id = "s4",
+            name = "Hidroponia A",
+            greenhouseId = "gh2",
+            greenhouseName = "Invernadero Norte",
+            area = 80.0,
+            clientId = "1"
+        ),
+        // Sectors for client "2" (Jean Pierre)
+        Sector(
+            id = "s5",
+            name = "Section Principale",
+            greenhouseId = "gh4",
+            greenhouseName = "Serre Principale",
+            area = 250.0,
+            clientId = "2"
+        ),
+        // Sectors for client "4" (Maria Muller)
+        Sector(
+            id = "s6",
+            name = "Bereich 1",
+            greenhouseId = "gh5",
+            greenhouseName = "Gewächshaus A",
+            area = 175.5,
+            clientId = "4"
+        ),
+        Sector(
+            id = "s7",
+            name = "Bereich 2",
+            greenhouseId = "gh6",
+            greenhouseName = "Gewächshaus B",
+            area = 90.0,
+            clientId = "4"
+        )
+    )
+
+    override suspend fun getSectorsByClientId(clientId: String): Result<List<Sector>> = runCatching {
+        delay(400)
+        mockSectors.filter { it.clientId == clientId }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun createSector(sector: Sector): Result<Sector> = runCatching {
+        delay(600)
+        val newSector = sector.copy(id = Uuid.random().toString())
+        mockSectors.add(newSector)
+        newSector
+    }
+
+    override suspend fun updateSector(sector: Sector): Result<Sector> = runCatching {
+        delay(500)
+        val index = mockSectors.indexOfFirst { it.id == sector.id }
+        if (index == -1) {
+            throw NoSuchElementException("Sector with id ${sector.id} not found")
+        }
+        mockSectors[index] = sector
+        sector
+    }
+
+    override suspend fun deleteSector(id: String): Result<Unit> = runCatching {
+        delay(400)
+        val index = mockSectors.indexOfFirst { it.id == id }
+        if (index == -1) {
+            throw NoSuchElementException("Sector with id $id not found")
+        }
+        mockSectors.removeAt(index)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/SettingsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/data/repository/SettingsRepositoryImpl.kt
@@ -1,0 +1,94 @@
+package com.apptolast.greenhouse.admin.data.repository
+
+import com.apptolast.greenhouse.admin.data.model.Setting
+import com.apptolast.greenhouse.admin.domain.repository.SettingsRepository
+import kotlinx.coroutines.delay
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Mock implementation of SettingsRepository.
+ * Provides hardcoded data for development. Replace with real API calls later.
+ */
+class SettingsRepositoryImpl : SettingsRepository {
+
+    private val mockSettings = mutableListOf(
+        // Settings for client "1" (Elena Rodriguez)
+        Setting(
+            id = "s1",
+            key = "notification_email",
+            value = "elena@greenhouse.com",
+            description = "Email address for receiving notifications",
+            clientId = "1"
+        ),
+        Setting(
+            id = "s2",
+            key = "temperature_unit",
+            value = "celsius",
+            description = "Temperature display unit (celsius/fahrenheit)",
+            clientId = "1"
+        ),
+        Setting(
+            id = "s3",
+            key = "alert_threshold_temp",
+            value = "35",
+            description = "Temperature threshold for high alerts (degrees)",
+            clientId = "1"
+        ),
+        Setting(
+            id = "s4",
+            key = "language",
+            value = "es",
+            description = "Preferred language for communications",
+            clientId = "1"
+        ),
+        // Settings for client "2" (Jean Pierre)
+        Setting(
+            id = "s5",
+            key = "language",
+            value = "fr",
+            description = "Langue preferee pour les communications",
+            clientId = "2"
+        ),
+        // Settings for client "4" (Maria Muller)
+        Setting(
+            id = "s6",
+            key = "temperature_unit",
+            value = "celsius",
+            description = "Temperatureinheit (celsius/fahrenheit)",
+            clientId = "4"
+        )
+    )
+
+    override suspend fun getSettingsByClientId(clientId: String): Result<List<Setting>> = runCatching {
+        delay(400)
+        mockSettings.filter { it.clientId == clientId }.sortedBy { it.key }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun createSetting(setting: Setting): Result<Setting> = runCatching {
+        delay(600)
+        val newSetting = setting.copy(id = Uuid.random().toString())
+        mockSettings.add(newSetting)
+        newSetting
+    }
+
+    override suspend fun updateSetting(setting: Setting): Result<Setting> = runCatching {
+        delay(500)
+        val index = mockSettings.indexOfFirst { it.id == setting.id }
+        if (index == -1) {
+            throw NoSuchElementException("Setting with id ${setting.id} not found")
+        }
+        mockSettings[index] = setting
+        setting
+    }
+
+    override suspend fun deleteSetting(id: String): Result<Unit> = runCatching {
+        delay(400)
+        val index = mockSettings.indexOfFirst { it.id == id }
+        if (index == -1) {
+            throw NoSuchElementException("Setting with id $id not found")
+        }
+        mockSettings.removeAt(index)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/di/DataModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/di/DataModule.kt
@@ -1,10 +1,20 @@
 package com.apptolast.greenhouse.admin.di
 
+import com.apptolast.greenhouse.admin.data.repository.AlertsRepositoryImpl
 import com.apptolast.greenhouse.admin.data.repository.ClientsRepositoryImpl
 import com.apptolast.greenhouse.admin.data.repository.DashboardRepositoryImpl
+import com.apptolast.greenhouse.admin.data.repository.DevicesRepositoryImpl
+import com.apptolast.greenhouse.admin.data.repository.GreenhousesRepositoryImpl
+import com.apptolast.greenhouse.admin.data.repository.SectorsRepositoryImpl
+import com.apptolast.greenhouse.admin.data.repository.SettingsRepositoryImpl
 import com.apptolast.greenhouse.admin.data.repository.UsersRepositoryImpl
+import com.apptolast.greenhouse.admin.domain.repository.AlertsRepository
 import com.apptolast.greenhouse.admin.domain.repository.ClientsRepository
 import com.apptolast.greenhouse.admin.domain.repository.DashboardRepository
+import com.apptolast.greenhouse.admin.domain.repository.DevicesRepository
+import com.apptolast.greenhouse.admin.domain.repository.GreenhousesRepository
+import com.apptolast.greenhouse.admin.domain.repository.SectorsRepository
+import com.apptolast.greenhouse.admin.domain.repository.SettingsRepository
 import com.apptolast.greenhouse.admin.domain.repository.UsersRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -25,4 +35,9 @@ val dataModule = module {
     singleOf(::DashboardRepositoryImpl) bind DashboardRepository::class
     singleOf(::ClientsRepositoryImpl) bind ClientsRepository::class
     singleOf(::UsersRepositoryImpl) bind UsersRepository::class
+    singleOf(::GreenhousesRepositoryImpl) bind GreenhousesRepository::class
+    singleOf(::SectorsRepositoryImpl) bind SectorsRepository::class
+    singleOf(::DevicesRepositoryImpl) bind DevicesRepository::class
+    singleOf(::AlertsRepositoryImpl) bind AlertsRepository::class
+    singleOf(::SettingsRepositoryImpl) bind SettingsRepository::class
 }

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/di/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/di/PresentationModule.kt
@@ -20,6 +20,6 @@ val presentationModule = module {
 
     // Client Detail (with clientId parameter)
     viewModel { (clientId: String) ->
-        ClientDetailViewModel(clientId, get(), get(), get())
+        ClientDetailViewModel(clientId, get(), get(), get(), get(), get(), get(), get(), get())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/AlertsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/AlertsRepository.kt
@@ -1,0 +1,37 @@
+package com.apptolast.greenhouse.admin.domain.repository
+
+import com.apptolast.greenhouse.admin.data.model.Alert
+
+/**
+ * Repository interface for alert data operations.
+ * All methods return Result<T> for consistent error handling.
+ */
+interface AlertsRepository {
+    /**
+     * Fetches all alerts for a specific client.
+     * @param clientId The client ID to filter alerts by
+     * @return Result containing list of Alert or error
+     */
+    suspend fun getAlertsByClientId(clientId: String): Result<List<Alert>>
+
+    /**
+     * Creates a new alert for a client.
+     * @param alert The alert data to create
+     * @return Result containing the created Alert or error
+     */
+    suspend fun createAlert(alert: Alert): Result<Alert>
+
+    /**
+     * Updates an existing alert.
+     * @param alert The alert data to update (must include valid id)
+     * @return Result containing the updated Alert or error
+     */
+    suspend fun updateAlert(alert: Alert): Result<Alert>
+
+    /**
+     * Deletes an alert by ID.
+     * @param id The alert ID to delete
+     * @return Result containing success or error
+     */
+    suspend fun deleteAlert(id: String): Result<Unit>
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/DevicesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/DevicesRepository.kt
@@ -1,0 +1,37 @@
+package com.apptolast.greenhouse.admin.domain.repository
+
+import com.apptolast.greenhouse.admin.data.model.Device
+
+/**
+ * Repository interface for device data operations.
+ * All methods return Result<T> for consistent error handling.
+ */
+interface DevicesRepository {
+    /**
+     * Fetches all devices for a specific client.
+     * @param clientId The client ID to filter devices by
+     * @return Result containing list of Device or error
+     */
+    suspend fun getDevicesByClientId(clientId: String): Result<List<Device>>
+
+    /**
+     * Creates a new device for a client.
+     * @param device The device data to create
+     * @return Result containing the created Device or error
+     */
+    suspend fun createDevice(device: Device): Result<Device>
+
+    /**
+     * Updates an existing device.
+     * @param device The device data to update (must include valid id)
+     * @return Result containing the updated Device or error
+     */
+    suspend fun updateDevice(device: Device): Result<Device>
+
+    /**
+     * Deletes a device by ID.
+     * @param id The device ID to delete
+     * @return Result containing success or error
+     */
+    suspend fun deleteDevice(id: String): Result<Unit>
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/GreenhousesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/GreenhousesRepository.kt
@@ -1,0 +1,37 @@
+package com.apptolast.greenhouse.admin.domain.repository
+
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
+
+/**
+ * Repository interface for greenhouse data operations.
+ * All methods return Result<T> for consistent error handling.
+ */
+interface GreenhousesRepository {
+    /**
+     * Fetches all greenhouses for a specific client.
+     * @param clientId The client ID to filter greenhouses by
+     * @return Result containing list of Greenhouse or error
+     */
+    suspend fun getGreenhousesByClientId(clientId: String): Result<List<Greenhouse>>
+
+    /**
+     * Creates a new greenhouse for a client.
+     * @param greenhouse The greenhouse data to create
+     * @return Result containing the created Greenhouse or error
+     */
+    suspend fun createGreenhouse(greenhouse: Greenhouse): Result<Greenhouse>
+
+    /**
+     * Updates an existing greenhouse.
+     * @param greenhouse The greenhouse data to update (must include valid id)
+     * @return Result containing the updated Greenhouse or error
+     */
+    suspend fun updateGreenhouse(greenhouse: Greenhouse): Result<Greenhouse>
+
+    /**
+     * Deletes a greenhouse by ID.
+     * @param id The greenhouse ID to delete
+     * @return Result containing success or error
+     */
+    suspend fun deleteGreenhouse(id: String): Result<Unit>
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/SectorsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/SectorsRepository.kt
@@ -1,0 +1,37 @@
+package com.apptolast.greenhouse.admin.domain.repository
+
+import com.apptolast.greenhouse.admin.data.model.Sector
+
+/**
+ * Repository interface for sector data operations.
+ * All methods return Result<T> for consistent error handling.
+ */
+interface SectorsRepository {
+    /**
+     * Fetches all sectors for a specific client.
+     * @param clientId The client ID to filter sectors by
+     * @return Result containing list of Sector or error
+     */
+    suspend fun getSectorsByClientId(clientId: String): Result<List<Sector>>
+
+    /**
+     * Creates a new sector for a client.
+     * @param sector The sector data to create
+     * @return Result containing the created Sector or error
+     */
+    suspend fun createSector(sector: Sector): Result<Sector>
+
+    /**
+     * Updates an existing sector.
+     * @param sector The sector data to update (must include valid id)
+     * @return Result containing the updated Sector or error
+     */
+    suspend fun updateSector(sector: Sector): Result<Sector>
+
+    /**
+     * Deletes a sector by ID.
+     * @param id The sector ID to delete
+     * @return Result containing success or error
+     */
+    suspend fun deleteSector(id: String): Result<Unit>
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/domain/repository/SettingsRepository.kt
@@ -1,0 +1,38 @@
+package com.apptolast.greenhouse.admin.domain.repository
+
+import com.apptolast.greenhouse.admin.data.model.Setting
+
+/**
+ * Repository interface for managing settings.
+ * Defines the contract for settings data operations.
+ */
+interface SettingsRepository {
+
+    /**
+     * Retrieves all settings for a specific client.
+     * @param clientId The ID of the client
+     * @return Result containing list of settings or error
+     */
+    suspend fun getSettingsByClientId(clientId: String): Result<List<Setting>>
+
+    /**
+     * Creates a new setting.
+     * @param setting The setting to create (id will be generated)
+     * @return Result containing the created setting with generated ID or error
+     */
+    suspend fun createSetting(setting: Setting): Result<Setting>
+
+    /**
+     * Updates an existing setting.
+     * @param setting The setting with updated values
+     * @return Result containing the updated setting or error
+     */
+    suspend fun updateSetting(setting: Setting): Result<Setting>
+
+    /**
+     * Deletes a setting by ID.
+     * @param id The ID of the setting to delete
+     * @return Result indicating success or failure
+     */
+    suspend fun deleteSetting(id: String): Result<Unit>
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/AlertsTable.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/AlertsTable.kt
@@ -1,0 +1,413 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Alert
+import com.apptolast.greenhouse.admin.data.model.AlertSeverity
+import com.apptolast.greenhouse.admin.data.model.AlertStatus
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.action_delete
+import greenhouseadmin.composeapp.generated.resources.action_edit
+import greenhouseadmin.composeapp.generated.resources.alert_status_dismissed
+import greenhouseadmin.composeapp.generated.resources.alert_status_read
+import greenhouseadmin.composeapp.generated.resources.alert_status_unread
+import greenhouseadmin.composeapp.generated.resources.header_actions
+import greenhouseadmin.composeapp.generated.resources.header_date
+import greenhouseadmin.composeapp.generated.resources.header_severity
+import greenhouseadmin.composeapp.generated.resources.header_status
+import greenhouseadmin.composeapp.generated.resources.header_title
+import greenhouseadmin.composeapp.generated.resources.severity_critical
+import greenhouseadmin.composeapp.generated.resources.severity_high
+import greenhouseadmin.composeapp.generated.resources.severity_low
+import greenhouseadmin.composeapp.generated.resources.severity_medium
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.time.Clock
+
+/**
+ * Table displaying list of alerts with headers and rows.
+ */
+@Composable
+fun AlertsTable(
+    alerts: List<Alert>,
+    onEditAlert: (Alert) -> Unit = {},
+    onDeleteAlert: (Alert) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column {
+            // Header row
+            AlertsTableHeader()
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+
+            // Alert rows
+            alerts.forEach { alert ->
+                AlertTableRow(
+                    alert = alert,
+                    onEdit = { onEditAlert(alert) },
+                    onDelete = { onDeleteAlert(alert) }
+                )
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlertsTableHeader(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(Res.string.header_title),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1.5f)
+        )
+        Text(
+            text = stringResource(Res.string.header_severity),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = stringResource(Res.string.header_status),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = stringResource(Res.string.header_date),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = stringResource(Res.string.header_actions),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(80.dp),
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun AlertTableRow(
+    alert: Alert,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // TITLE with avatar
+        Row(
+            modifier = Modifier.weight(1.5f),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AlertAvatar(
+                initials = alert.initials,
+                severity = alert.severity,
+                modifier = Modifier.size(36.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = alert.title,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        // SEVERITY
+        AlertSeverityBadge(
+            severity = alert.severity,
+            modifier = Modifier.weight(1f)
+        )
+
+        // STATUS
+        AlertStatusBadge(
+            status = alert.status,
+            modifier = Modifier.weight(1f)
+        )
+
+        // DATE
+        Text(
+            text = formatRelativeTime(alert.createdAt),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+
+        // ACTIONS
+        Row(
+            modifier = Modifier.width(80.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            IconButton(
+                onClick = onEdit,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = stringResource(Res.string.action_edit),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = stringResource(Res.string.action_delete),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Formats a timestamp to relative time (e.g., "2 hours ago", "1 day ago").
+ */
+private fun formatRelativeTime(timestamp: Long): String {
+    val now = Clock.System.now().toEpochMilliseconds()
+    val diff = now - timestamp
+
+    val seconds = diff / 1000
+    val minutes = seconds / 60
+    val hours = minutes / 60
+    val days = hours / 24
+
+    return when {
+        days > 0 -> "${days}d ago"
+        hours > 0 -> "${hours}h ago"
+        minutes > 0 -> "${minutes}m ago"
+        else -> "Just now"
+    }
+}
+
+/**
+ * Avatar component for alerts with colored background based on severity.
+ */
+@Composable
+fun AlertAvatar(
+    initials: String,
+    severity: AlertSeverity,
+    modifier: Modifier = Modifier
+) {
+    val backgroundColor = when (severity) {
+        AlertSeverity.LOW -> Color(0xFF2196F3) // Blue
+        AlertSeverity.MEDIUM -> Color(0xFFFF9800) // Orange
+        AlertSeverity.HIGH -> Color(0xFFF44336) // Red
+        AlertSeverity.CRITICAL -> Color(0xFF9C27B0) // Purple
+    }
+
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initials,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+/**
+ * Severity badge for alerts.
+ */
+@Composable
+fun AlertSeverityBadge(
+    severity: AlertSeverity,
+    modifier: Modifier = Modifier
+) {
+    val (backgroundColor, textColor, textRes) = when (severity) {
+        AlertSeverity.LOW -> Triple(
+            Color(0xFF2196F3).copy(alpha = 0.15f),
+            Color(0xFF2196F3),
+            Res.string.severity_low
+        )
+
+        AlertSeverity.MEDIUM -> Triple(
+            Color(0xFFFF9800).copy(alpha = 0.15f),
+            Color(0xFFFF9800),
+            Res.string.severity_medium
+        )
+
+        AlertSeverity.HIGH -> Triple(
+            Color(0xFFF44336).copy(alpha = 0.15f),
+            Color(0xFFF44336),
+            Res.string.severity_high
+        )
+
+        AlertSeverity.CRITICAL -> Triple(
+            Color(0xFF9C27B0).copy(alpha = 0.15f),
+            Color(0xFF9C27B0),
+            Res.string.severity_critical
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(backgroundColor)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = stringResource(textRes),
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+/**
+ * Status badge for alerts.
+ */
+@Composable
+fun AlertStatusBadge(
+    status: AlertStatus,
+    modifier: Modifier = Modifier
+) {
+    val (backgroundColor, textColor, textRes) = when (status) {
+        AlertStatus.UNREAD -> Triple(
+            Color(0xFFF44336).copy(alpha = 0.15f),
+            Color(0xFFF44336),
+            Res.string.alert_status_unread
+        )
+
+        AlertStatus.READ -> Triple(
+            Color(0xFF00E676).copy(alpha = 0.15f),
+            Color(0xFF00E676),
+            Res.string.alert_status_read
+        )
+
+        AlertStatus.DISMISSED -> Triple(
+            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.15f),
+            MaterialTheme.colorScheme.onSurfaceVariant,
+            Res.string.alert_status_dismissed
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(backgroundColor)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = stringResource(textRes),
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+private object AlertsTablePreviewData {
+    val sampleAlerts = listOf(
+        Alert(
+            id = "1",
+            title = "Temperatura alta en Sector A",
+            severity = AlertSeverity.HIGH,
+            status = AlertStatus.UNREAD,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 3600000,
+            clientId = "client1"
+        ),
+        Alert(
+            id = "2",
+            title = "Humedad baja detectada",
+            severity = AlertSeverity.MEDIUM,
+            status = AlertStatus.READ,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 86400000,
+            clientId = "client1"
+        ),
+        Alert(
+            id = "3",
+            title = "Sensor CO2 desconectado",
+            severity = AlertSeverity.CRITICAL,
+            status = AlertStatus.UNREAD,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 1800000,
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun AlertsTablePreview() {
+    GreenhouseAdminTheme {
+        AlertsTable(alerts = AlertsTablePreviewData.sampleAlerts)
+    }
+}
+
+@Preview
+@Composable
+private fun AlertAvatarPreview() {
+    GreenhouseAdminTheme {
+        Row {
+            AlertAvatar(initials = "TA", severity = AlertSeverity.LOW)
+            Spacer(modifier = Modifier.width(8.dp))
+            AlertAvatar(initials = "HB", severity = AlertSeverity.MEDIUM)
+            Spacer(modifier = Modifier.width(8.dp))
+            AlertAvatar(initials = "SC", severity = AlertSeverity.HIGH)
+            Spacer(modifier = Modifier.width(8.dp))
+            AlertAvatar(initials = "CR", severity = AlertSeverity.CRITICAL)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailAlertsTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailAlertsTab.kt
@@ -1,0 +1,212 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Alert
+import com.apptolast.greenhouse.admin.data.model.AlertSeverity
+import com.apptolast.greenhouse.admin.data.model.AlertStatus
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.LocalAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.ProvideAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.components.common.ErrorContent
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.alerts_empty
+import greenhouseadmin.composeapp.generated.resources.alerts_subtitle
+import greenhouseadmin.composeapp.generated.resources.alerts_title
+import greenhouseadmin.composeapp.generated.resources.new_alert
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.time.Clock
+
+/**
+ * Alerts tab content for the client detail screen.
+ * Displays a table of alerts with add/edit/delete functionality.
+ * On compact screens, the add button is hidden (FAB is shown by parent).
+ */
+@Composable
+fun ClientDetailAlertsTab(
+    alerts: List<Alert>,
+    isLoading: Boolean = false,
+    error: String? = null,
+    onAddAlert: () -> Unit = {},
+    onEditAlert: (Alert) -> Unit = {},
+    onDeleteAlert: (Alert) -> Unit = {},
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val windowInfo = LocalAppWindowInfo.current
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Header with title and Add button (button hidden on compact - FAB shown by parent)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(
+                    text = stringResource(Res.string.alerts_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = stringResource(Res.string.alerts_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Show button only on expanded screens
+            if (!windowInfo.isCompact) {
+                Button(
+                    onClick = onAddAlert,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.new_alert))
+                }
+            }
+        }
+
+        // Content
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            error != null -> {
+                ErrorContent(
+                    message = error,
+                    onRetry = onRetry
+                )
+            }
+
+            alerts.isEmpty() -> {
+                EmptyAlertsContent()
+            }
+
+            else -> {
+                AlertsTable(
+                    alerts = alerts,
+                    onEditAlert = onEditAlert,
+                    onDeleteAlert = onDeleteAlert
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyAlertsContent(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(48.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(Res.string.alerts_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private object ClientDetailAlertsTabPreviewData {
+    val sampleAlerts = listOf(
+        Alert(
+            id = "1",
+            title = "Temperatura alta en Sector A",
+            severity = AlertSeverity.HIGH,
+            status = AlertStatus.UNREAD,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 3600000,
+            clientId = "client1"
+        ),
+        Alert(
+            id = "2",
+            title = "Humedad baja detectada",
+            severity = AlertSeverity.MEDIUM,
+            status = AlertStatus.READ,
+            createdAt = Clock.System.now().toEpochMilliseconds() - 86400000,
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun ClientDetailAlertsTabPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailAlertsTab(alerts = ClientDetailAlertsTabPreviewData.sampleAlerts)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailAlertsTabEmptyPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailAlertsTab(alerts = emptyList())
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailAlertsTabLoadingPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailAlertsTab(alerts = emptyList(), isLoading = true)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailDevicesTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailDevicesTab.kt
@@ -1,0 +1,209 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Device
+import com.apptolast.greenhouse.admin.data.model.DeviceStatus
+import com.apptolast.greenhouse.admin.data.model.DeviceType
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.LocalAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.ProvideAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.components.common.ErrorContent
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.devices_empty
+import greenhouseadmin.composeapp.generated.resources.devices_subtitle
+import greenhouseadmin.composeapp.generated.resources.devices_title
+import greenhouseadmin.composeapp.generated.resources.new_device
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Devices tab content for the client detail screen.
+ * Displays a table of devices with add/edit/delete functionality.
+ * On compact screens, the add button is hidden (FAB is shown by parent).
+ */
+@Composable
+fun ClientDetailDevicesTab(
+    devices: List<Device>,
+    isLoading: Boolean = false,
+    error: String? = null,
+    onAddDevice: () -> Unit = {},
+    onEditDevice: (Device) -> Unit = {},
+    onDeleteDevice: (Device) -> Unit = {},
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val windowInfo = LocalAppWindowInfo.current
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Header with title and Add button (button hidden on compact - FAB shown by parent)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(
+                    text = stringResource(Res.string.devices_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = stringResource(Res.string.devices_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Show button only on expanded screens
+            if (!windowInfo.isCompact) {
+                Button(
+                    onClick = onAddDevice,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.new_device))
+                }
+            }
+        }
+
+        // Content
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            error != null -> {
+                ErrorContent(
+                    message = error,
+                    onRetry = onRetry
+                )
+            }
+
+            devices.isEmpty() -> {
+                EmptyDevicesContent()
+            }
+
+            else -> {
+                DevicesTable(
+                    devices = devices,
+                    onEditDevice = onEditDevice,
+                    onDeleteDevice = onDeleteDevice
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyDevicesContent(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(48.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(Res.string.devices_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private object ClientDetailDevicesTabPreviewData {
+    val sampleDevices = listOf(
+        Device(
+            id = "1",
+            name = "Sensor Temperatura A1",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "client1"
+        ),
+        Device(
+            id = "2",
+            name = "Valvula Riego Norte",
+            type = DeviceType.ACTUATOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun ClientDetailDevicesTabPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailDevicesTab(devices = ClientDetailDevicesTabPreviewData.sampleDevices)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailDevicesTabEmptyPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailDevicesTab(devices = emptyList())
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailDevicesTabLoadingPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailDevicesTab(devices = emptyList(), isLoading = true)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailGreenhousesTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailGreenhousesTab.kt
@@ -1,0 +1,208 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
+import com.apptolast.greenhouse.admin.data.model.GreenhouseStatus
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.LocalAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.ProvideAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.components.common.ErrorContent
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.greenhouses_empty
+import greenhouseadmin.composeapp.generated.resources.greenhouses_subtitle
+import greenhouseadmin.composeapp.generated.resources.greenhouses_title
+import greenhouseadmin.composeapp.generated.resources.new_greenhouse
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Greenhouses tab content for the client detail screen.
+ * Displays a table of greenhouses with add/edit/delete functionality.
+ * On compact screens, the add button is hidden (FAB is shown by parent).
+ */
+@Composable
+fun ClientDetailGreenhousesTab(
+    greenhouses: List<Greenhouse>,
+    isLoading: Boolean = false,
+    error: String? = null,
+    onAddGreenhouse: () -> Unit = {},
+    onEditGreenhouse: (Greenhouse) -> Unit = {},
+    onDeleteGreenhouse: (Greenhouse) -> Unit = {},
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val windowInfo = LocalAppWindowInfo.current
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Header with title and Add button (button hidden on compact - FAB shown by parent)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(
+                    text = stringResource(Res.string.greenhouses_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = stringResource(Res.string.greenhouses_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Show button only on expanded screens
+            if (!windowInfo.isCompact) {
+                Button(
+                    onClick = onAddGreenhouse,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.new_greenhouse))
+                }
+            }
+        }
+
+        // Content
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            error != null -> {
+                ErrorContent(
+                    message = error,
+                    onRetry = onRetry
+                )
+            }
+
+            greenhouses.isEmpty() -> {
+                EmptyGreenhousesContent()
+            }
+
+            else -> {
+                GreenhousesTable(
+                    greenhouses = greenhouses,
+                    onEditGreenhouse = onEditGreenhouse,
+                    onDeleteGreenhouse = onDeleteGreenhouse
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyGreenhousesContent(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(48.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(Res.string.greenhouses_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private object ClientDetailGreenhousesTabPreviewData {
+    val sampleGreenhouses = listOf(
+        Greenhouse(
+            id = "1",
+            name = "Invernadero Principal",
+            description = "Produccion de tomates y pimientos",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "client1"
+        ),
+        Greenhouse(
+            id = "2",
+            name = "Invernadero Norte",
+            description = "Cultivo de lechugas hidroponicas",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun ClientDetailGreenhousesTabPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailGreenhousesTab(greenhouses = ClientDetailGreenhousesTabPreviewData.sampleGreenhouses)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailGreenhousesTabEmptyPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailGreenhousesTab(greenhouses = emptyList())
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailGreenhousesTabLoadingPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailGreenhousesTab(greenhouses = emptyList(), isLoading = true)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailSectorsTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailSectorsTab.kt
@@ -1,0 +1,209 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Sector
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.LocalAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.ProvideAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.components.common.ErrorContent
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.new_sector
+import greenhouseadmin.composeapp.generated.resources.sectors_empty
+import greenhouseadmin.composeapp.generated.resources.sectors_subtitle
+import greenhouseadmin.composeapp.generated.resources.sectors_title
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Sectors tab content for the client detail screen.
+ * Displays a table of sectors with add/edit/delete functionality.
+ * On compact screens, the add button is hidden (FAB is shown by parent).
+ */
+@Composable
+fun ClientDetailSectorsTab(
+    sectors: List<Sector>,
+    isLoading: Boolean = false,
+    error: String? = null,
+    onAddSector: () -> Unit = {},
+    onEditSector: (Sector) -> Unit = {},
+    onDeleteSector: (Sector) -> Unit = {},
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val windowInfo = LocalAppWindowInfo.current
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Header with title and Add button (button hidden on compact - FAB shown by parent)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(
+                    text = stringResource(Res.string.sectors_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = stringResource(Res.string.sectors_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Show button only on expanded screens
+            if (!windowInfo.isCompact) {
+                Button(
+                    onClick = onAddSector,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.new_sector))
+                }
+            }
+        }
+
+        // Content
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            error != null -> {
+                ErrorContent(
+                    message = error,
+                    onRetry = onRetry
+                )
+            }
+
+            sectors.isEmpty() -> {
+                EmptySectorsContent()
+            }
+
+            else -> {
+                SectorsTable(
+                    sectors = sectors,
+                    onEditSector = onEditSector,
+                    onDeleteSector = onDeleteSector
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptySectorsContent(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(48.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(Res.string.sectors_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private object ClientDetailSectorsTabPreviewData {
+    val sampleSectors = listOf(
+        Sector(
+            id = "1",
+            name = "Sector Norte A",
+            greenhouseId = "gh1",
+            greenhouseName = "Invernadero Principal",
+            area = 150.0,
+            clientId = "client1"
+        ),
+        Sector(
+            id = "2",
+            name = "Sector Norte B",
+            greenhouseId = "gh1",
+            greenhouseName = "Invernadero Principal",
+            area = 120.5,
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun ClientDetailSectorsTabPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailSectorsTab(sectors = ClientDetailSectorsTabPreviewData.sampleSectors)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailSectorsTabEmptyPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailSectorsTab(sectors = emptyList())
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailSectorsTabLoadingPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailSectorsTab(sectors = emptyList(), isLoading = true)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailSettingsTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/ClientDetailSettingsTab.kt
@@ -1,0 +1,207 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Setting
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.LocalAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.adaptive.ProvideAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.components.common.ErrorContent
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.new_setting
+import greenhouseadmin.composeapp.generated.resources.settings_empty
+import greenhouseadmin.composeapp.generated.resources.settings_subtitle
+import greenhouseadmin.composeapp.generated.resources.settings_title
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Settings tab content for the client detail screen.
+ * Displays a table of settings with add/edit/delete functionality.
+ * On compact screens, the add button is hidden (FAB is shown by parent).
+ */
+@Composable
+fun ClientDetailSettingsTab(
+    settings: List<Setting>,
+    isLoading: Boolean = false,
+    error: String? = null,
+    onAddSetting: () -> Unit = {},
+    onEditSetting: (Setting) -> Unit = {},
+    onDeleteSetting: (Setting) -> Unit = {},
+    onRetry: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val windowInfo = LocalAppWindowInfo.current
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Header with title and Add button (button hidden on compact - FAB shown by parent)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(
+                    text = stringResource(Res.string.settings_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = stringResource(Res.string.settings_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Show button only on expanded screens
+            if (!windowInfo.isCompact) {
+                Button(
+                    onClick = onAddSetting,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.new_setting))
+                }
+            }
+        }
+
+        // Content
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            error != null -> {
+                ErrorContent(
+                    message = error,
+                    onRetry = onRetry
+                )
+            }
+
+            settings.isEmpty() -> {
+                EmptySettingsContent()
+            }
+
+            else -> {
+                SettingsTable(
+                    settings = settings,
+                    onEditSetting = onEditSetting,
+                    onDeleteSetting = onDeleteSetting
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptySettingsContent(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(48.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(Res.string.settings_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private object ClientDetailSettingsTabPreviewData {
+    val sampleSettings = listOf(
+        Setting(
+            id = "1",
+            key = "notification_email",
+            value = "test@example.com",
+            description = "Email address for receiving notifications",
+            clientId = "client1"
+        ),
+        Setting(
+            id = "2",
+            key = "temperature_unit",
+            value = "celsius",
+            description = "Temperature display unit",
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun ClientDetailSettingsTabPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailSettingsTab(settings = ClientDetailSettingsTabPreviewData.sampleSettings)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailSettingsTabEmptyPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailSettingsTab(settings = emptyList())
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailSettingsTabLoadingPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailSettingsTab(settings = emptyList(), isLoading = true)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/DevicesTable.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/DevicesTable.kt
@@ -1,0 +1,347 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Device
+import com.apptolast.greenhouse.admin.data.model.DeviceStatus
+import com.apptolast.greenhouse.admin.data.model.DeviceType
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.action_delete
+import greenhouseadmin.composeapp.generated.resources.action_edit
+import greenhouseadmin.composeapp.generated.resources.device_status_offline
+import greenhouseadmin.composeapp.generated.resources.device_status_online
+import greenhouseadmin.composeapp.generated.resources.device_type_actuator
+import greenhouseadmin.composeapp.generated.resources.device_type_sensor
+import greenhouseadmin.composeapp.generated.resources.header_actions
+import greenhouseadmin.composeapp.generated.resources.header_name
+import greenhouseadmin.composeapp.generated.resources.header_status
+import greenhouseadmin.composeapp.generated.resources.header_type
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Table displaying list of devices with headers and rows.
+ */
+@Composable
+fun DevicesTable(
+    devices: List<Device>,
+    onEditDevice: (Device) -> Unit = {},
+    onDeleteDevice: (Device) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column {
+            // Header row
+            DevicesTableHeader()
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+
+            // Device rows
+            devices.forEach { device ->
+                DeviceTableRow(
+                    device = device,
+                    onEdit = { onEditDevice(device) },
+                    onDelete = { onDeleteDevice(device) }
+                )
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun DevicesTableHeader(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(Res.string.header_name),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1.5f)
+        )
+        Text(
+            text = stringResource(Res.string.header_type),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = stringResource(Res.string.header_status),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = stringResource(Res.string.header_actions),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(80.dp),
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun DeviceTableRow(
+    device: Device,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // NAME with avatar
+        Row(
+            modifier = Modifier.weight(1.5f),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            DeviceAvatar(
+                initials = device.initials,
+                deviceType = device.type,
+                modifier = Modifier.size(36.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = device.name,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        // TYPE
+        DeviceTypeBadge(
+            type = device.type,
+            modifier = Modifier.weight(1f)
+        )
+
+        // STATUS
+        DeviceStatusBadge(
+            status = device.status,
+            modifier = Modifier.weight(1f)
+        )
+
+        // ACTIONS
+        Row(
+            modifier = Modifier.width(80.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            IconButton(
+                onClick = onEdit,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = stringResource(Res.string.action_edit),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = stringResource(Res.string.action_delete),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Avatar component for devices with colored background based on type.
+ */
+@Composable
+fun DeviceAvatar(
+    initials: String,
+    deviceType: DeviceType,
+    modifier: Modifier = Modifier
+) {
+    val backgroundColor = when (deviceType) {
+        DeviceType.SENSOR -> Color(0xFF9C27B0) // Purple for sensors
+        DeviceType.ACTUATOR -> Color(0xFFFF9800) // Orange for actuators
+    }
+
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initials,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+/**
+ * Type badge for devices.
+ */
+@Composable
+fun DeviceTypeBadge(
+    type: DeviceType,
+    modifier: Modifier = Modifier
+) {
+    val (backgroundColor, textColor, textRes) = when (type) {
+        DeviceType.SENSOR -> Triple(
+            Color(0xFF9C27B0).copy(alpha = 0.15f),
+            Color(0xFF9C27B0),
+            Res.string.device_type_sensor
+        )
+
+        DeviceType.ACTUATOR -> Triple(
+            Color(0xFFFF9800).copy(alpha = 0.15f),
+            Color(0xFFFF9800),
+            Res.string.device_type_actuator
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(backgroundColor)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = stringResource(textRes),
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+/**
+ * Status badge for devices.
+ */
+@Composable
+fun DeviceStatusBadge(
+    status: DeviceStatus,
+    modifier: Modifier = Modifier
+) {
+    val (backgroundColor, textColor, textRes) = when (status) {
+        DeviceStatus.ONLINE -> Triple(
+            Color(0xFF00E676).copy(alpha = 0.15f),
+            Color(0xFF00E676),
+            Res.string.device_status_online
+        )
+
+        DeviceStatus.OFFLINE -> Triple(
+            MaterialTheme.colorScheme.error.copy(alpha = 0.15f),
+            MaterialTheme.colorScheme.error,
+            Res.string.device_status_offline
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(backgroundColor)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = stringResource(textRes),
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+private object DevicesTablePreviewData {
+    val sampleDevices = listOf(
+        Device(
+            id = "1",
+            name = "Sensor Temperatura A1",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "client1"
+        ),
+        Device(
+            id = "2",
+            name = "Valvula Riego Norte",
+            type = DeviceType.ACTUATOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "client1"
+        ),
+        Device(
+            id = "3",
+            name = "Sensor CO2 B2",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.OFFLINE,
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun DevicesTablePreview() {
+    GreenhouseAdminTheme {
+        DevicesTable(devices = DevicesTablePreviewData.sampleDevices)
+    }
+}
+
+@Preview
+@Composable
+private fun DeviceAvatarPreview() {
+    GreenhouseAdminTheme {
+        Row {
+            DeviceAvatar(initials = "ST", deviceType = DeviceType.SENSOR)
+            Spacer(modifier = Modifier.width(8.dp))
+            DeviceAvatar(initials = "VR", deviceType = DeviceType.ACTUATOR)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/GreenhousesTable.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/GreenhousesTable.kt
@@ -1,0 +1,300 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
+import com.apptolast.greenhouse.admin.data.model.GreenhouseStatus
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.action_delete
+import greenhouseadmin.composeapp.generated.resources.action_edit
+import greenhouseadmin.composeapp.generated.resources.header_actions
+import greenhouseadmin.composeapp.generated.resources.header_description
+import greenhouseadmin.composeapp.generated.resources.header_name
+import greenhouseadmin.composeapp.generated.resources.header_status
+import greenhouseadmin.composeapp.generated.resources.status_active
+import greenhouseadmin.composeapp.generated.resources.status_inactive
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Table displaying list of greenhouses with headers and rows.
+ */
+@Composable
+fun GreenhousesTable(
+    greenhouses: List<Greenhouse>,
+    onEditGreenhouse: (Greenhouse) -> Unit = {},
+    onDeleteGreenhouse: (Greenhouse) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column {
+            // Header row
+            GreenhousesTableHeader()
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+
+            // Greenhouse rows
+            greenhouses.forEach { greenhouse ->
+                GreenhouseTableRow(
+                    greenhouse = greenhouse,
+                    onEdit = { onEditGreenhouse(greenhouse) },
+                    onDelete = { onDeleteGreenhouse(greenhouse) }
+                )
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun GreenhousesTableHeader(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(Res.string.header_name),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1.5f)
+        )
+        Text(
+            text = stringResource(Res.string.header_description),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(2f)
+        )
+        Text(
+            text = stringResource(Res.string.header_status),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = stringResource(Res.string.header_actions),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(80.dp),
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun GreenhouseTableRow(
+    greenhouse: Greenhouse,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // NAME with avatar
+        Row(
+            modifier = Modifier.weight(1.5f),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            GreenhouseAvatar(
+                initials = greenhouse.initials,
+                modifier = Modifier.size(36.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = greenhouse.name,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        // DESCRIPTION
+        Text(
+            text = greenhouse.description,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(2f),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        // STATUS
+        GreenhouseStatusBadge(
+            status = greenhouse.status,
+            modifier = Modifier.weight(1f)
+        )
+
+        // ACTIONS
+        Row(
+            modifier = Modifier.width(80.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            IconButton(
+                onClick = onEdit,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = stringResource(Res.string.action_edit),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = stringResource(Res.string.action_delete),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Avatar component for greenhouses with colored background based on initials.
+ */
+@Composable
+fun GreenhouseAvatar(
+    initials: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(Color(0xFF4CAF50)), // Green for greenhouses
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initials,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+/**
+ * Status badge for greenhouses.
+ */
+@Composable
+fun GreenhouseStatusBadge(
+    status: GreenhouseStatus,
+    modifier: Modifier = Modifier
+) {
+    val (backgroundColor, textColor, textRes) = when (status) {
+        GreenhouseStatus.ACTIVE -> Triple(
+            Color(0xFF00E676).copy(alpha = 0.15f),
+            Color(0xFF00E676),
+            Res.string.status_active
+        )
+
+        GreenhouseStatus.INACTIVE -> Triple(
+            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.1f),
+            MaterialTheme.colorScheme.onSurfaceVariant,
+            Res.string.status_inactive
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(backgroundColor)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = stringResource(textRes),
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+private object GreenhousesTablePreviewData {
+    val sampleGreenhouses = listOf(
+        Greenhouse(
+            id = "1",
+            name = "Invernadero Principal",
+            description = "Produccion de tomates y pimientos",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "client1"
+        ),
+        Greenhouse(
+            id = "2",
+            name = "Invernadero Norte",
+            description = "Cultivo de lechugas hidroponicas",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "client1"
+        ),
+        Greenhouse(
+            id = "3",
+            name = "Invernadero Experimental",
+            description = "Pruebas de nuevas variedades",
+            status = GreenhouseStatus.INACTIVE,
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun GreenhousesTablePreview() {
+    GreenhouseAdminTheme {
+        GreenhousesTable(greenhouses = GreenhousesTablePreviewData.sampleGreenhouses)
+    }
+}
+
+@Preview
+@Composable
+private fun GreenhouseAvatarPreview() {
+    GreenhouseAdminTheme {
+        GreenhouseAvatar(initials = "IP")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/SectorsTable.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/SectorsTable.kt
@@ -1,0 +1,265 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Sector
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.action_delete
+import greenhouseadmin.composeapp.generated.resources.action_edit
+import greenhouseadmin.composeapp.generated.resources.header_actions
+import greenhouseadmin.composeapp.generated.resources.header_area
+import greenhouseadmin.composeapp.generated.resources.header_greenhouse
+import greenhouseadmin.composeapp.generated.resources.header_name
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Table displaying list of sectors with headers and rows.
+ */
+@Composable
+fun SectorsTable(
+    sectors: List<Sector>,
+    onEditSector: (Sector) -> Unit = {},
+    onDeleteSector: (Sector) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column {
+            // Header row
+            SectorsTableHeader()
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+
+            // Sector rows
+            sectors.forEach { sector ->
+                SectorTableRow(
+                    sector = sector,
+                    onEdit = { onEditSector(sector) },
+                    onDelete = { onDeleteSector(sector) }
+                )
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectorsTableHeader(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(Res.string.header_name),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1.5f)
+        )
+        Text(
+            text = stringResource(Res.string.header_greenhouse),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1.5f)
+        )
+        Text(
+            text = stringResource(Res.string.header_area),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = stringResource(Res.string.header_actions),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(80.dp),
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun SectorTableRow(
+    sector: Sector,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // NAME with avatar
+        Row(
+            modifier = Modifier.weight(1.5f),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SectorAvatar(
+                initials = sector.initials,
+                modifier = Modifier.size(36.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = sector.name,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        // GREENHOUSE
+        Text(
+            text = sector.greenhouseName,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1.5f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        // AREA
+        Text(
+            text = sector.formattedArea,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+
+        // ACTIONS
+        Row(
+            modifier = Modifier.width(80.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            IconButton(
+                onClick = onEdit,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = stringResource(Res.string.action_edit),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = stringResource(Res.string.action_delete),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Avatar component for sectors with colored background based on initials.
+ */
+@Composable
+fun SectorAvatar(
+    initials: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(Color(0xFF2196F3)), // Blue for sectors
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initials,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+private object SectorsTablePreviewData {
+    val sampleSectors = listOf(
+        Sector(
+            id = "1",
+            name = "Sector Norte A",
+            greenhouseId = "gh1",
+            greenhouseName = "Invernadero Principal",
+            area = 150.0,
+            clientId = "client1"
+        ),
+        Sector(
+            id = "2",
+            name = "Sector Norte B",
+            greenhouseId = "gh1",
+            greenhouseName = "Invernadero Principal",
+            area = 120.5,
+            clientId = "client1"
+        ),
+        Sector(
+            id = "3",
+            name = "Sector Sur",
+            greenhouseId = "gh2",
+            greenhouseName = "Invernadero Norte",
+            area = 200.0,
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun SectorsTablePreview() {
+    GreenhouseAdminTheme {
+        SectorsTable(sectors = SectorsTablePreviewData.sampleSectors)
+    }
+}
+
+@Preview
+@Composable
+private fun SectorAvatarPreview() {
+    GreenhouseAdminTheme {
+        SectorAvatar(initials = "SN")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/SettingsTable.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/clients/detail/SettingsTable.kt
@@ -1,0 +1,270 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.apptolast.greenhouse.admin.data.model.Setting
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.action_delete
+import greenhouseadmin.composeapp.generated.resources.action_edit
+import greenhouseadmin.composeapp.generated.resources.header_actions
+import greenhouseadmin.composeapp.generated.resources.header_description
+import greenhouseadmin.composeapp.generated.resources.header_key
+import greenhouseadmin.composeapp.generated.resources.header_value
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Table displaying list of settings with headers and rows.
+ */
+@Composable
+fun SettingsTable(
+    settings: List<Setting>,
+    onEditSetting: (Setting) -> Unit = {},
+    onDeleteSetting: (Setting) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column {
+            // Header row
+            SettingsTableHeader()
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+
+            // Setting rows
+            settings.forEach { setting ->
+                SettingTableRow(
+                    setting = setting,
+                    onEdit = { onEditSetting(setting) },
+                    onDelete = { onDeleteSetting(setting) }
+                )
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsTableHeader(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(Res.string.header_key),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = stringResource(Res.string.header_value),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = stringResource(Res.string.header_description),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1.5f)
+        )
+        Text(
+            text = stringResource(Res.string.header_actions),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(80.dp),
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun SettingTableRow(
+    setting: Setting,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // KEY with avatar
+        Row(
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SettingAvatar(
+                initials = setting.initials,
+                modifier = Modifier.size(36.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = setting.key,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        // VALUE
+        Text(
+            text = setting.value,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        // DESCRIPTION
+        Text(
+            text = setting.description,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1.5f),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        // ACTIONS
+        Row(
+            modifier = Modifier.width(80.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            IconButton(
+                onClick = onEdit,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = stringResource(Res.string.action_edit),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = stringResource(Res.string.action_delete),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Avatar component for settings with colored background.
+ */
+@Composable
+fun SettingAvatar(
+    initials: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(Color(0xFF607D8B)), // Blue grey color for settings
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initials,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+private object SettingsTablePreviewData {
+    val sampleSettings = listOf(
+        Setting(
+            id = "1",
+            key = "notification_email",
+            value = "test@example.com",
+            description = "Email address for receiving notifications",
+            clientId = "client1"
+        ),
+        Setting(
+            id = "2",
+            key = "temperature_unit",
+            value = "celsius",
+            description = "Temperature display unit",
+            clientId = "client1"
+        ),
+        Setting(
+            id = "3",
+            key = "language",
+            value = "es",
+            description = "Preferred language for communications",
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun SettingsTablePreview() {
+    GreenhouseAdminTheme {
+        SettingsTable(settings = SettingsTablePreviewData.sampleSettings)
+    }
+}
+
+@Preview
+@Composable
+private fun SettingAvatarPreview() {
+    GreenhouseAdminTheme {
+        Row {
+            SettingAvatar(initials = "NO")
+            Spacer(modifier = Modifier.width(8.dp))
+            SettingAvatar(initials = "TE")
+            Spacer(modifier = Modifier.width(8.dp))
+            SettingAvatar(initials = "LA")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/AlertFormDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/AlertFormDialog.kt
@@ -1,0 +1,442 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.apptolast.greenhouse.admin.data.model.Alert
+import com.apptolast.greenhouse.admin.data.model.AlertFormData
+import com.apptolast.greenhouse.admin.data.model.AlertSeverity
+import com.apptolast.greenhouse.admin.data.model.AlertStatus
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import com.apptolast.greenhouse.admin.presentation.viewmodel.AlertFormMode
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.alert_status_dismissed
+import greenhouseadmin.composeapp.generated.resources.alert_status_read
+import greenhouseadmin.composeapp.generated.resources.alert_status_unread
+import greenhouseadmin.composeapp.generated.resources.button_cancel
+import greenhouseadmin.composeapp.generated.resources.button_create_alert
+import greenhouseadmin.composeapp.generated.resources.button_save
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_alert_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_alert_title
+import greenhouseadmin.composeapp.generated.resources.dialog_new_alert_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_new_alert_title
+import greenhouseadmin.composeapp.generated.resources.error_name_min_length
+import greenhouseadmin.composeapp.generated.resources.error_title_required
+import greenhouseadmin.composeapp.generated.resources.field_severity
+import greenhouseadmin.composeapp.generated.resources.field_status
+import greenhouseadmin.composeapp.generated.resources.field_title
+import greenhouseadmin.composeapp.generated.resources.severity_critical
+import greenhouseadmin.composeapp.generated.resources.severity_high
+import greenhouseadmin.composeapp.generated.resources.severity_low
+import greenhouseadmin.composeapp.generated.resources.severity_medium
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.time.Clock
+
+/**
+ * Dialog for creating or editing an alert.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlertFormDialog(
+    mode: AlertFormMode,
+    isSubmitting: Boolean = false,
+    error: String? = null,
+    onSubmit: (title: String, severity: AlertSeverity, status: AlertStatus) -> Unit = { _, _, _ -> },
+    onDismiss: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val initialFormData = remember(mode) {
+        when (mode) {
+            is AlertFormMode.Create -> AlertFormData()
+            is AlertFormMode.Edit -> AlertFormData(
+                title = mode.alert.title,
+                severity = mode.alert.severity,
+                status = mode.alert.status
+            )
+        }
+    }
+
+    var formData by remember(mode) { mutableStateOf(initialFormData) }
+    var validationErrors by remember { mutableStateOf(AlertFormData.ValidationErrors()) }
+    var hasAttemptedSubmit by remember { mutableStateOf(false) }
+    var severityExpanded by remember { mutableStateOf(false) }
+    var statusExpanded by remember { mutableStateOf(false) }
+
+    val titleRequiredMsg = stringResource(Res.string.error_title_required)
+    val nameMinLengthMsg = stringResource(Res.string.error_name_min_length)
+
+    fun getErrorMessage(errorKey: String?): String? {
+        return when (errorKey) {
+            "error_title_required" -> titleRequiredMsg
+            "error_name_min_length" -> nameMinLengthMsg
+            else -> null
+        }
+    }
+
+    val isEditMode = mode is AlertFormMode.Edit
+    val dialogTitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_alert_title)
+    } else {
+        stringResource(Res.string.dialog_new_alert_title)
+    }
+    val dialogSubtitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_alert_subtitle)
+    } else {
+        stringResource(Res.string.dialog_new_alert_subtitle)
+    }
+    val submitButtonText = if (isEditMode) {
+        stringResource(Res.string.button_save)
+    } else {
+        stringResource(Res.string.button_create_alert)
+    }
+
+    // Severity options
+    val severityLowText = stringResource(Res.string.severity_low)
+    val severityMediumText = stringResource(Res.string.severity_medium)
+    val severityHighText = stringResource(Res.string.severity_high)
+    val severityCriticalText = stringResource(Res.string.severity_critical)
+
+    // Status options
+    val statusUnreadText = stringResource(Res.string.alert_status_unread)
+    val statusReadText = stringResource(Res.string.alert_status_read)
+    val statusDismissedText = stringResource(Res.string.alert_status_dismissed)
+
+    Dialog(onDismissRequest = { if (!isSubmitting) onDismiss() }) {
+        Card(
+            modifier = modifier.width(420.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                // Title
+                Text(
+                    text = dialogTitle,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                // Subtitle
+                Text(
+                    text = dialogSubtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Title field
+                AlertFormTextField(
+                    value = formData.title,
+                    onValueChange = {
+                        formData = formData.copy(title = it)
+                        if (hasAttemptedSubmit) validationErrors = formData.validate()
+                    },
+                    label = stringResource(Res.string.field_title),
+                    error = getErrorMessage(validationErrors.title),
+                    enabled = !isSubmitting
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Severity dropdown
+                Column {
+                    Text(
+                        text = stringResource(Res.string.field_severity),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    ExposedDropdownMenuBox(
+                        expanded = severityExpanded,
+                        onExpandedChange = { if (!isSubmitting) severityExpanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = when (formData.severity) {
+                                AlertSeverity.LOW -> severityLowText
+                                AlertSeverity.MEDIUM -> severityMediumText
+                                AlertSeverity.HIGH -> severityHighText
+                                AlertSeverity.CRITICAL -> severityCriticalText
+                            },
+                            onValueChange = {},
+                            readOnly = true,
+                            enabled = !isSubmitting,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = severityExpanded) },
+                            shape = RoundedCornerShape(8.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+                            )
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = severityExpanded,
+                            onDismissRequest = { severityExpanded = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(severityLowText) },
+                                onClick = {
+                                    formData = formData.copy(severity = AlertSeverity.LOW)
+                                    severityExpanded = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(severityMediumText) },
+                                onClick = {
+                                    formData = formData.copy(severity = AlertSeverity.MEDIUM)
+                                    severityExpanded = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(severityHighText) },
+                                onClick = {
+                                    formData = formData.copy(severity = AlertSeverity.HIGH)
+                                    severityExpanded = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(severityCriticalText) },
+                                onClick = {
+                                    formData = formData.copy(severity = AlertSeverity.CRITICAL)
+                                    severityExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Status dropdown
+                Column {
+                    Text(
+                        text = stringResource(Res.string.field_status),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    ExposedDropdownMenuBox(
+                        expanded = statusExpanded,
+                        onExpandedChange = { if (!isSubmitting) statusExpanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = when (formData.status) {
+                                AlertStatus.UNREAD -> statusUnreadText
+                                AlertStatus.READ -> statusReadText
+                                AlertStatus.DISMISSED -> statusDismissedText
+                            },
+                            onValueChange = {},
+                            readOnly = true,
+                            enabled = !isSubmitting,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = statusExpanded) },
+                            shape = RoundedCornerShape(8.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+                            )
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = statusExpanded,
+                            onDismissRequest = { statusExpanded = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(statusUnreadText) },
+                                onClick = {
+                                    formData = formData.copy(status = AlertStatus.UNREAD)
+                                    statusExpanded = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(statusReadText) },
+                                onClick = {
+                                    formData = formData.copy(status = AlertStatus.READ)
+                                    statusExpanded = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(statusDismissedText) },
+                                onClick = {
+                                    formData = formData.copy(status = AlertStatus.DISMISSED)
+                                    statusExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                // Error message
+                if (error != null) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        Text(stringResource(Res.string.button_cancel))
+                    }
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Button(
+                        onClick = {
+                            hasAttemptedSubmit = true
+                            validationErrors = formData.validate()
+                            if (!validationErrors.hasErrors) {
+                                onSubmit(formData.title, formData.severity, formData.status)
+                            }
+                        },
+                        enabled = !isSubmitting,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary
+                        ),
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        if (isSubmitting) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                strokeWidth = 2.dp
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Text(submitButtonText)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlertFormTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    error: String?,
+    enabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
+            isError = error != null,
+            singleLine = true,
+            shape = RoundedCornerShape(8.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                errorBorderColor = MaterialTheme.colorScheme.error
+            )
+        )
+
+        if (error != null) {
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+private object AlertFormDialogPreviewData {
+    val sampleAlert = Alert(
+        id = "1",
+        title = "Temperatura alta en Sector A",
+        severity = AlertSeverity.HIGH,
+        status = AlertStatus.UNREAD,
+        createdAt = Clock.System.now().toEpochMilliseconds(),
+        clientId = "client1"
+    )
+}
+
+@Preview
+@Composable
+private fun AlertFormDialogCreatePreview() {
+    GreenhouseAdminTheme {
+        AlertFormDialog(mode = AlertFormMode.Create)
+    }
+}
+
+@Preview
+@Composable
+private fun AlertFormDialogEditPreview() {
+    GreenhouseAdminTheme {
+        AlertFormDialog(mode = AlertFormMode.Edit(AlertFormDialogPreviewData.sampleAlert))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/DeviceFormDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/DeviceFormDialog.kt
@@ -1,0 +1,404 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.apptolast.greenhouse.admin.data.model.Device
+import com.apptolast.greenhouse.admin.data.model.DeviceFormData
+import com.apptolast.greenhouse.admin.data.model.DeviceStatus
+import com.apptolast.greenhouse.admin.data.model.DeviceType
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import com.apptolast.greenhouse.admin.presentation.viewmodel.DeviceFormMode
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.button_cancel
+import greenhouseadmin.composeapp.generated.resources.button_create_device
+import greenhouseadmin.composeapp.generated.resources.button_save
+import greenhouseadmin.composeapp.generated.resources.device_status_offline
+import greenhouseadmin.composeapp.generated.resources.device_status_online
+import greenhouseadmin.composeapp.generated.resources.device_type_actuator
+import greenhouseadmin.composeapp.generated.resources.device_type_sensor
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_device_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_device_title
+import greenhouseadmin.composeapp.generated.resources.dialog_new_device_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_new_device_title
+import greenhouseadmin.composeapp.generated.resources.error_name_min_length
+import greenhouseadmin.composeapp.generated.resources.field_status
+import greenhouseadmin.composeapp.generated.resources.field_type
+import greenhouseadmin.composeapp.generated.resources.label_name
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Dialog for creating or editing a device.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeviceFormDialog(
+    mode: DeviceFormMode,
+    isSubmitting: Boolean = false,
+    error: String? = null,
+    onSubmit: (name: String, type: DeviceType, status: DeviceStatus) -> Unit = { _, _, _ -> },
+    onDismiss: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val initialFormData = remember(mode) {
+        when (mode) {
+            is DeviceFormMode.Create -> DeviceFormData()
+            is DeviceFormMode.Edit -> DeviceFormData(
+                name = mode.device.name,
+                type = mode.device.type,
+                status = mode.device.status
+            )
+        }
+    }
+
+    var formData by remember(mode) { mutableStateOf(initialFormData) }
+    var validationErrors by remember { mutableStateOf(DeviceFormData.ValidationErrors()) }
+    var hasAttemptedSubmit by remember { mutableStateOf(false) }
+    var typeExpanded by remember { mutableStateOf(false) }
+    var statusExpanded by remember { mutableStateOf(false) }
+
+    val nameErrorMsg = stringResource(Res.string.error_name_min_length)
+
+    fun getErrorMessage(errorKey: String?): String? {
+        return when (errorKey) {
+            "error_name_min_length" -> nameErrorMsg
+            else -> null
+        }
+    }
+
+    val isEditMode = mode is DeviceFormMode.Edit
+    val dialogTitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_device_title)
+    } else {
+        stringResource(Res.string.dialog_new_device_title)
+    }
+    val dialogSubtitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_device_subtitle)
+    } else {
+        stringResource(Res.string.dialog_new_device_subtitle)
+    }
+    val submitButtonText = if (isEditMode) {
+        stringResource(Res.string.button_save)
+    } else {
+        stringResource(Res.string.button_create_device)
+    }
+
+    val typeSensorText = stringResource(Res.string.device_type_sensor)
+    val typeActuatorText = stringResource(Res.string.device_type_actuator)
+    val statusOnlineText = stringResource(Res.string.device_status_online)
+    val statusOfflineText = stringResource(Res.string.device_status_offline)
+
+    Dialog(onDismissRequest = { if (!isSubmitting) onDismiss() }) {
+        Card(
+            modifier = modifier.width(420.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                // Title
+                Text(
+                    text = dialogTitle,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                // Subtitle
+                Text(
+                    text = dialogSubtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Name field
+                DeviceFormTextField(
+                    value = formData.name,
+                    onValueChange = {
+                        formData = formData.copy(name = it)
+                        if (hasAttemptedSubmit) validationErrors = formData.validate()
+                    },
+                    label = stringResource(Res.string.label_name),
+                    error = getErrorMessage(validationErrors.name),
+                    enabled = !isSubmitting
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Type dropdown
+                Column {
+                    Text(
+                        text = stringResource(Res.string.field_type),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    ExposedDropdownMenuBox(
+                        expanded = typeExpanded,
+                        onExpandedChange = { if (!isSubmitting) typeExpanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = when (formData.type) {
+                                DeviceType.SENSOR -> typeSensorText
+                                DeviceType.ACTUATOR -> typeActuatorText
+                            },
+                            onValueChange = {},
+                            readOnly = true,
+                            enabled = !isSubmitting,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeExpanded) },
+                            shape = RoundedCornerShape(8.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+                            )
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = typeExpanded,
+                            onDismissRequest = { typeExpanded = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(typeSensorText) },
+                                onClick = {
+                                    formData = formData.copy(type = DeviceType.SENSOR)
+                                    typeExpanded = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(typeActuatorText) },
+                                onClick = {
+                                    formData = formData.copy(type = DeviceType.ACTUATOR)
+                                    typeExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Status dropdown
+                Column {
+                    Text(
+                        text = stringResource(Res.string.field_status),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    ExposedDropdownMenuBox(
+                        expanded = statusExpanded,
+                        onExpandedChange = { if (!isSubmitting) statusExpanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = when (formData.status) {
+                                DeviceStatus.ONLINE -> statusOnlineText
+                                DeviceStatus.OFFLINE -> statusOfflineText
+                            },
+                            onValueChange = {},
+                            readOnly = true,
+                            enabled = !isSubmitting,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = statusExpanded) },
+                            shape = RoundedCornerShape(8.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+                            )
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = statusExpanded,
+                            onDismissRequest = { statusExpanded = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(statusOnlineText) },
+                                onClick = {
+                                    formData = formData.copy(status = DeviceStatus.ONLINE)
+                                    statusExpanded = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(statusOfflineText) },
+                                onClick = {
+                                    formData = formData.copy(status = DeviceStatus.OFFLINE)
+                                    statusExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                // Error message
+                if (error != null) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        Text(stringResource(Res.string.button_cancel))
+                    }
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Button(
+                        onClick = {
+                            hasAttemptedSubmit = true
+                            validationErrors = formData.validate()
+                            if (!validationErrors.hasErrors) {
+                                onSubmit(formData.name, formData.type, formData.status)
+                            }
+                        },
+                        enabled = !isSubmitting,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary
+                        ),
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        if (isSubmitting) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                strokeWidth = 2.dp
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Text(submitButtonText)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeviceFormTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    error: String?,
+    enabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
+            isError = error != null,
+            singleLine = true,
+            shape = RoundedCornerShape(8.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                errorBorderColor = MaterialTheme.colorScheme.error
+            )
+        )
+
+        if (error != null) {
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+private object DeviceFormDialogPreviewData {
+    val sampleDevice = Device(
+        id = "1",
+        name = "Sensor Temperatura A1",
+        type = DeviceType.SENSOR,
+        status = DeviceStatus.ONLINE,
+        clientId = "client1"
+    )
+}
+
+@Preview
+@Composable
+private fun DeviceFormDialogCreatePreview() {
+    GreenhouseAdminTheme {
+        DeviceFormDialog(mode = DeviceFormMode.Create)
+    }
+}
+
+@Preview
+@Composable
+private fun DeviceFormDialogEditPreview() {
+    GreenhouseAdminTheme {
+        DeviceFormDialog(mode = DeviceFormMode.Edit(DeviceFormDialogPreviewData.sampleDevice))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/GreenhouseFormDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/GreenhouseFormDialog.kt
@@ -1,0 +1,359 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
+import com.apptolast.greenhouse.admin.data.model.GreenhouseFormData
+import com.apptolast.greenhouse.admin.data.model.GreenhouseStatus
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import com.apptolast.greenhouse.admin.presentation.viewmodel.GreenhouseFormMode
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.button_cancel
+import greenhouseadmin.composeapp.generated.resources.button_create_greenhouse
+import greenhouseadmin.composeapp.generated.resources.button_save
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_greenhouse_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_greenhouse_title
+import greenhouseadmin.composeapp.generated.resources.dialog_new_greenhouse_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_new_greenhouse_title
+import greenhouseadmin.composeapp.generated.resources.error_name_min_length
+import greenhouseadmin.composeapp.generated.resources.field_description
+import greenhouseadmin.composeapp.generated.resources.field_status
+import greenhouseadmin.composeapp.generated.resources.label_name
+import greenhouseadmin.composeapp.generated.resources.status_active
+import greenhouseadmin.composeapp.generated.resources.status_inactive
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Dialog for creating or editing a greenhouse.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GreenhouseFormDialog(
+    mode: GreenhouseFormMode,
+    isSubmitting: Boolean = false,
+    error: String? = null,
+    onSubmit: (name: String, description: String, status: GreenhouseStatus) -> Unit = { _, _, _ -> },
+    onDismiss: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val initialFormData = remember(mode) {
+        when (mode) {
+            is GreenhouseFormMode.Create -> GreenhouseFormData()
+            is GreenhouseFormMode.Edit -> GreenhouseFormData(
+                name = mode.greenhouse.name,
+                description = mode.greenhouse.description,
+                status = mode.greenhouse.status
+            )
+        }
+    }
+
+    var formData by remember(mode) { mutableStateOf(initialFormData) }
+    var validationErrors by remember { mutableStateOf(GreenhouseFormData.ValidationErrors()) }
+    var hasAttemptedSubmit by remember { mutableStateOf(false) }
+    var statusExpanded by remember { mutableStateOf(false) }
+
+    val nameErrorMsg = stringResource(Res.string.error_name_min_length)
+
+    fun getErrorMessage(errorKey: String?): String? {
+        return when (errorKey) {
+            "error_name_min_length" -> nameErrorMsg
+            else -> null
+        }
+    }
+
+    val isEditMode = mode is GreenhouseFormMode.Edit
+    val dialogTitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_greenhouse_title)
+    } else {
+        stringResource(Res.string.dialog_new_greenhouse_title)
+    }
+    val dialogSubtitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_greenhouse_subtitle)
+    } else {
+        stringResource(Res.string.dialog_new_greenhouse_subtitle)
+    }
+    val submitButtonText = if (isEditMode) {
+        stringResource(Res.string.button_save)
+    } else {
+        stringResource(Res.string.button_create_greenhouse)
+    }
+
+    val statusActiveText = stringResource(Res.string.status_active)
+    val statusInactiveText = stringResource(Res.string.status_inactive)
+
+    Dialog(onDismissRequest = { if (!isSubmitting) onDismiss() }) {
+        Card(
+            modifier = modifier.width(420.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                // Title
+                Text(
+                    text = dialogTitle,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                // Subtitle
+                Text(
+                    text = dialogSubtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Name field
+                GreenhouseFormTextField(
+                    value = formData.name,
+                    onValueChange = {
+                        formData = formData.copy(name = it)
+                        if (hasAttemptedSubmit) validationErrors = formData.validate()
+                    },
+                    label = stringResource(Res.string.label_name),
+                    error = getErrorMessage(validationErrors.name),
+                    enabled = !isSubmitting
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Description field
+                GreenhouseFormTextField(
+                    value = formData.description,
+                    onValueChange = {
+                        formData = formData.copy(description = it)
+                    },
+                    label = stringResource(Res.string.field_description),
+                    error = null,
+                    enabled = !isSubmitting,
+                    singleLine = false,
+                    maxLines = 3
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Status dropdown
+                Column {
+                    Text(
+                        text = stringResource(Res.string.field_status),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    ExposedDropdownMenuBox(
+                        expanded = statusExpanded,
+                        onExpandedChange = { if (!isSubmitting) statusExpanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = when (formData.status) {
+                                GreenhouseStatus.ACTIVE -> statusActiveText
+                                GreenhouseStatus.INACTIVE -> statusInactiveText
+                            },
+                            onValueChange = {},
+                            readOnly = true,
+                            enabled = !isSubmitting,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = statusExpanded) },
+                            shape = RoundedCornerShape(8.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+                            )
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = statusExpanded,
+                            onDismissRequest = { statusExpanded = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(statusActiveText) },
+                                onClick = {
+                                    formData = formData.copy(status = GreenhouseStatus.ACTIVE)
+                                    statusExpanded = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(statusInactiveText) },
+                                onClick = {
+                                    formData = formData.copy(status = GreenhouseStatus.INACTIVE)
+                                    statusExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                // Error message
+                if (error != null) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        Text(stringResource(Res.string.button_cancel))
+                    }
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Button(
+                        onClick = {
+                            hasAttemptedSubmit = true
+                            validationErrors = formData.validate()
+                            if (!validationErrors.hasErrors) {
+                                onSubmit(formData.name, formData.description, formData.status)
+                            }
+                        },
+                        enabled = !isSubmitting,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary
+                        ),
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        if (isSubmitting) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                strokeWidth = 2.dp
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Text(submitButtonText)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GreenhouseFormTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    error: String?,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    singleLine: Boolean = true,
+    maxLines: Int = 1
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
+            isError = error != null,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            shape = RoundedCornerShape(8.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                errorBorderColor = MaterialTheme.colorScheme.error
+            )
+        )
+
+        if (error != null) {
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+private object GreenhouseFormDialogPreviewData {
+    val sampleGreenhouse = Greenhouse(
+        id = "1",
+        name = "Invernadero Principal",
+        description = "Produccion de tomates y pimientos",
+        status = GreenhouseStatus.ACTIVE,
+        clientId = "client1"
+    )
+}
+
+@Preview
+@Composable
+private fun GreenhouseFormDialogCreatePreview() {
+    GreenhouseAdminTheme {
+        GreenhouseFormDialog(mode = GreenhouseFormMode.Create)
+    }
+}
+
+@Preview
+@Composable
+private fun GreenhouseFormDialogEditPreview() {
+    GreenhouseAdminTheme {
+        GreenhouseFormDialog(mode = GreenhouseFormMode.Edit(GreenhouseFormDialogPreviewData.sampleGreenhouse))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/SectorFormDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/SectorFormDialog.kt
@@ -1,0 +1,401 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
+import com.apptolast.greenhouse.admin.data.model.GreenhouseStatus
+import com.apptolast.greenhouse.admin.data.model.Sector
+import com.apptolast.greenhouse.admin.data.model.SectorFormData
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import com.apptolast.greenhouse.admin.presentation.viewmodel.SectorFormMode
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.button_cancel
+import greenhouseadmin.composeapp.generated.resources.button_create_sector
+import greenhouseadmin.composeapp.generated.resources.button_save
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_sector_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_sector_title
+import greenhouseadmin.composeapp.generated.resources.dialog_new_sector_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_new_sector_title
+import greenhouseadmin.composeapp.generated.resources.error_area_invalid
+import greenhouseadmin.composeapp.generated.resources.error_area_positive
+import greenhouseadmin.composeapp.generated.resources.error_area_required
+import greenhouseadmin.composeapp.generated.resources.error_greenhouse_required
+import greenhouseadmin.composeapp.generated.resources.error_name_min_length
+import greenhouseadmin.composeapp.generated.resources.field_area
+import greenhouseadmin.composeapp.generated.resources.field_greenhouse
+import greenhouseadmin.composeapp.generated.resources.label_name
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Dialog for creating or editing a sector.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SectorFormDialog(
+    mode: SectorFormMode,
+    greenhouses: List<Greenhouse>,
+    isSubmitting: Boolean = false,
+    error: String? = null,
+    onSubmit: (name: String, greenhouseId: String, greenhouseName: String, area: Double) -> Unit = { _, _, _, _ -> },
+    onDismiss: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val initialFormData = remember(mode) {
+        when (mode) {
+            is SectorFormMode.Create -> SectorFormData()
+            is SectorFormMode.Edit -> SectorFormData(
+                name = mode.sector.name,
+                greenhouseId = mode.sector.greenhouseId,
+                area = mode.sector.area.toString()
+            )
+        }
+    }
+
+    var formData by remember(mode) { mutableStateOf(initialFormData) }
+    var validationErrors by remember { mutableStateOf(SectorFormData.ValidationErrors()) }
+    var hasAttemptedSubmit by remember { mutableStateOf(false) }
+    var greenhouseExpanded by remember { mutableStateOf(false) }
+
+    // Get error message strings
+    val nameErrorMsg = stringResource(Res.string.error_name_min_length)
+    val greenhouseRequiredMsg = stringResource(Res.string.error_greenhouse_required)
+    val areaRequiredMsg = stringResource(Res.string.error_area_required)
+    val areaInvalidMsg = stringResource(Res.string.error_area_invalid)
+    val areaPositiveMsg = stringResource(Res.string.error_area_positive)
+
+    fun getErrorMessage(errorKey: String?): String? {
+        return when (errorKey) {
+            "error_name_min_length" -> nameErrorMsg
+            "error_greenhouse_required" -> greenhouseRequiredMsg
+            "error_area_required" -> areaRequiredMsg
+            "error_area_invalid" -> areaInvalidMsg
+            "error_area_positive" -> areaPositiveMsg
+            else -> null
+        }
+    }
+
+    val isEditMode = mode is SectorFormMode.Edit
+    val dialogTitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_sector_title)
+    } else {
+        stringResource(Res.string.dialog_new_sector_title)
+    }
+    val dialogSubtitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_sector_subtitle)
+    } else {
+        stringResource(Res.string.dialog_new_sector_subtitle)
+    }
+    val submitButtonText = if (isEditMode) {
+        stringResource(Res.string.button_save)
+    } else {
+        stringResource(Res.string.button_create_sector)
+    }
+
+    val selectedGreenhouse = greenhouses.find { it.id == formData.greenhouseId }
+
+    Dialog(onDismissRequest = { if (!isSubmitting) onDismiss() }) {
+        Card(
+            modifier = modifier.width(420.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                // Title
+                Text(
+                    text = dialogTitle,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                // Subtitle
+                Text(
+                    text = dialogSubtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Name field
+                SectorFormTextField(
+                    value = formData.name,
+                    onValueChange = {
+                        formData = formData.copy(name = it)
+                        if (hasAttemptedSubmit) validationErrors = formData.validate()
+                    },
+                    label = stringResource(Res.string.label_name),
+                    error = getErrorMessage(validationErrors.name),
+                    enabled = !isSubmitting
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Greenhouse dropdown
+                Column {
+                    Text(
+                        text = stringResource(Res.string.field_greenhouse),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    ExposedDropdownMenuBox(
+                        expanded = greenhouseExpanded,
+                        onExpandedChange = { if (!isSubmitting) greenhouseExpanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = selectedGreenhouse?.name ?: "",
+                            onValueChange = {},
+                            readOnly = true,
+                            enabled = !isSubmitting,
+                            isError = hasAttemptedSubmit && validationErrors.greenhouseId != null,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = greenhouseExpanded) },
+                            shape = RoundedCornerShape(8.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                                errorBorderColor = MaterialTheme.colorScheme.error
+                            )
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = greenhouseExpanded,
+                            onDismissRequest = { greenhouseExpanded = false }
+                        ) {
+                            greenhouses.forEach { greenhouse ->
+                                DropdownMenuItem(
+                                    text = { Text(greenhouse.name) },
+                                    onClick = {
+                                        formData = formData.copy(greenhouseId = greenhouse.id)
+                                        greenhouseExpanded = false
+                                        if (hasAttemptedSubmit) validationErrors = formData.validate()
+                                    }
+                                )
+                            }
+                        }
+                    }
+
+                    if (hasAttemptedSubmit && validationErrors.greenhouseId != null) {
+                        Text(
+                            text = getErrorMessage(validationErrors.greenhouseId) ?: "",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Area field
+                SectorFormTextField(
+                    value = formData.area,
+                    onValueChange = {
+                        formData = formData.copy(area = it)
+                        if (hasAttemptedSubmit) validationErrors = formData.validate()
+                    },
+                    label = stringResource(Res.string.field_area),
+                    error = getErrorMessage(validationErrors.area),
+                    enabled = !isSubmitting,
+                    keyboardType = KeyboardType.Decimal
+                )
+
+                // Error message
+                if (error != null) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        Text(stringResource(Res.string.button_cancel))
+                    }
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Button(
+                        onClick = {
+                            hasAttemptedSubmit = true
+                            validationErrors = formData.validate()
+                            if (!validationErrors.hasErrors) {
+                                val greenhouseName = selectedGreenhouse?.name ?: ""
+                                onSubmit(formData.name, formData.greenhouseId, greenhouseName, formData.areaValue)
+                            }
+                        },
+                        enabled = !isSubmitting,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary
+                        ),
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        if (isSubmitting) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                strokeWidth = 2.dp
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Text(submitButtonText)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectorFormTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    error: String?,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    keyboardType: KeyboardType = KeyboardType.Text
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
+            isError = error != null,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+            shape = RoundedCornerShape(8.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                errorBorderColor = MaterialTheme.colorScheme.error
+            )
+        )
+
+        if (error != null) {
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+private object SectorFormDialogPreviewData {
+    val sampleSector = Sector(
+        id = "1",
+        name = "Sector Norte A",
+        greenhouseId = "gh1",
+        greenhouseName = "Invernadero Principal",
+        area = 150.0,
+        clientId = "client1"
+    )
+
+    val sampleGreenhouses = listOf(
+        Greenhouse(
+            id = "gh1",
+            name = "Invernadero Principal",
+            description = "Produccion de tomates",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "client1"
+        ),
+        Greenhouse(
+            id = "gh2",
+            name = "Invernadero Norte",
+            description = "Cultivo de lechugas",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "client1"
+        )
+    )
+}
+
+@Preview
+@Composable
+private fun SectorFormDialogCreatePreview() {
+    GreenhouseAdminTheme {
+        SectorFormDialog(
+            mode = SectorFormMode.Create,
+            greenhouses = SectorFormDialogPreviewData.sampleGreenhouses
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SectorFormDialogEditPreview() {
+    GreenhouseAdminTheme {
+        SectorFormDialog(
+            mode = SectorFormMode.Edit(SectorFormDialogPreviewData.sampleSector),
+            greenhouses = SectorFormDialogPreviewData.sampleGreenhouses
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/SettingFormDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/components/dialogs/SettingFormDialog.kt
@@ -1,0 +1,314 @@
+package com.apptolast.greenhouse.admin.presentation.ui.components.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.apptolast.greenhouse.admin.data.model.Setting
+import com.apptolast.greenhouse.admin.data.model.SettingFormData
+import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
+import com.apptolast.greenhouse.admin.presentation.viewmodel.SettingFormMode
+import greenhouseadmin.composeapp.generated.resources.Res
+import greenhouseadmin.composeapp.generated.resources.button_cancel
+import greenhouseadmin.composeapp.generated.resources.button_create_setting
+import greenhouseadmin.composeapp.generated.resources.button_save
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_setting_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_edit_setting_title
+import greenhouseadmin.composeapp.generated.resources.dialog_new_setting_subtitle
+import greenhouseadmin.composeapp.generated.resources.dialog_new_setting_title
+import greenhouseadmin.composeapp.generated.resources.error_key_invalid
+import greenhouseadmin.composeapp.generated.resources.error_key_min_length
+import greenhouseadmin.composeapp.generated.resources.error_key_required
+import greenhouseadmin.composeapp.generated.resources.error_value_required
+import greenhouseadmin.composeapp.generated.resources.field_description
+import greenhouseadmin.composeapp.generated.resources.field_key
+import greenhouseadmin.composeapp.generated.resources.field_value
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+/**
+ * Dialog for creating or editing a setting.
+ */
+@Composable
+fun SettingFormDialog(
+    mode: SettingFormMode,
+    isSubmitting: Boolean = false,
+    error: String? = null,
+    onSubmit: (key: String, value: String, description: String) -> Unit = { _, _, _ -> },
+    onDismiss: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val initialFormData = remember(mode) {
+        when (mode) {
+            is SettingFormMode.Create -> SettingFormData()
+            is SettingFormMode.Edit -> SettingFormData(
+                key = mode.setting.key,
+                value = mode.setting.value,
+                description = mode.setting.description
+            )
+        }
+    }
+
+    var formData by remember(mode) { mutableStateOf(initialFormData) }
+    var validationErrors by remember { mutableStateOf(SettingFormData.ValidationErrors()) }
+    var hasAttemptedSubmit by remember { mutableStateOf(false) }
+
+    val keyRequiredMsg = stringResource(Res.string.error_key_required)
+    val keyMinLengthMsg = stringResource(Res.string.error_key_min_length)
+    val keyInvalidMsg = stringResource(Res.string.error_key_invalid)
+    val valueRequiredMsg = stringResource(Res.string.error_value_required)
+
+    fun getErrorMessage(errorKey: String?): String? {
+        return when (errorKey) {
+            "error_key_required" -> keyRequiredMsg
+            "error_key_min_length" -> keyMinLengthMsg
+            "error_key_invalid" -> keyInvalidMsg
+            "error_value_required" -> valueRequiredMsg
+            else -> null
+        }
+    }
+
+    val isEditMode = mode is SettingFormMode.Edit
+    val dialogTitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_setting_title)
+    } else {
+        stringResource(Res.string.dialog_new_setting_title)
+    }
+    val dialogSubtitle = if (isEditMode) {
+        stringResource(Res.string.dialog_edit_setting_subtitle)
+    } else {
+        stringResource(Res.string.dialog_new_setting_subtitle)
+    }
+    val submitButtonText = if (isEditMode) {
+        stringResource(Res.string.button_save)
+    } else {
+        stringResource(Res.string.button_create_setting)
+    }
+
+    Dialog(onDismissRequest = { if (!isSubmitting) onDismiss() }) {
+        Card(
+            modifier = modifier.width(420.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                // Title
+                Text(
+                    text = dialogTitle,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                // Subtitle
+                Text(
+                    text = dialogSubtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Key field
+                SettingFormTextField(
+                    value = formData.key,
+                    onValueChange = {
+                        formData = formData.copy(key = it)
+                        if (hasAttemptedSubmit) validationErrors = formData.validate()
+                    },
+                    label = stringResource(Res.string.field_key),
+                    error = getErrorMessage(validationErrors.key),
+                    enabled = !isSubmitting && !isEditMode // Key is not editable in edit mode
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Value field
+                SettingFormTextField(
+                    value = formData.value,
+                    onValueChange = {
+                        formData = formData.copy(value = it)
+                        if (hasAttemptedSubmit) validationErrors = formData.validate()
+                    },
+                    label = stringResource(Res.string.field_value),
+                    error = getErrorMessage(validationErrors.value),
+                    enabled = !isSubmitting
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Description field (optional, multi-line)
+                SettingFormTextField(
+                    value = formData.description,
+                    onValueChange = {
+                        formData = formData.copy(description = it)
+                    },
+                    label = stringResource(Res.string.field_description),
+                    error = null,
+                    enabled = !isSubmitting,
+                    singleLine = false,
+                    maxLines = 3
+                )
+
+                // Error message
+                if (error != null) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        Text(stringResource(Res.string.button_cancel))
+                    }
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Button(
+                        onClick = {
+                            hasAttemptedSubmit = true
+                            validationErrors = formData.validate()
+                            if (!validationErrors.hasErrors) {
+                                onSubmit(formData.key, formData.value, formData.description)
+                            }
+                        },
+                        enabled = !isSubmitting,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary
+                        ),
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        if (isSubmitting) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                strokeWidth = 2.dp
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Text(submitButtonText)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingFormTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    error: String?,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    singleLine: Boolean = true,
+    maxLines: Int = 1
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = enabled,
+            isError = error != null,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            shape = RoundedCornerShape(8.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                errorBorderColor = MaterialTheme.colorScheme.error,
+                disabledBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                disabledTextColor = MaterialTheme.colorScheme.onSurface
+            )
+        )
+
+        if (error != null) {
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+private object SettingFormDialogPreviewData {
+    val sampleSetting = Setting(
+        id = "1",
+        key = "notification_email",
+        value = "test@example.com",
+        description = "Email address for receiving notifications",
+        clientId = "client1"
+    )
+}
+
+@Preview
+@Composable
+private fun SettingFormDialogCreatePreview() {
+    GreenhouseAdminTheme {
+        SettingFormDialog(mode = SettingFormMode.Create)
+    }
+}
+
+@Preview
+@Composable
+private fun SettingFormDialogEditPreview() {
+    GreenhouseAdminTheme {
+        SettingFormDialog(mode = SettingFormMode.Edit(SettingFormDialogPreviewData.sampleSetting))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/screens/ClientDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/ui/screens/ClientDetailScreen.kt
@@ -23,21 +23,35 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.apptolast.greenhouse.admin.data.model.Client
 import com.apptolast.greenhouse.admin.data.model.ClientStatus
+import com.apptolast.greenhouse.admin.data.model.Device
+import com.apptolast.greenhouse.admin.data.model.DeviceStatus
+import com.apptolast.greenhouse.admin.data.model.DeviceType
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
+import com.apptolast.greenhouse.admin.data.model.GreenhouseStatus
 import com.apptolast.greenhouse.admin.data.model.User
 import com.apptolast.greenhouse.admin.presentation.ui.adaptive.AdaptiveDimens
 import com.apptolast.greenhouse.admin.presentation.ui.adaptive.LocalAppWindowInfo
 import com.apptolast.greenhouse.admin.presentation.ui.adaptive.ProvideAppWindowInfo
+import com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail.ClientDetailAlertsTab
+import com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail.ClientDetailDevicesTab
 import com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail.ClientDetailGeneralTab
+import com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail.ClientDetailGreenhousesTab
 import com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail.ClientDetailHeader
+import com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail.ClientDetailSectorsTab
+import com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail.ClientDetailSettingsTab
 import com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail.ClientDetailTabBar
 import com.apptolast.greenhouse.admin.presentation.ui.components.clients.detail.ClientDetailUsersTab
-import com.apptolast.greenhouse.admin.presentation.ui.components.common.ComingSoonContent
 import com.apptolast.greenhouse.admin.presentation.ui.components.common.DashboardTopBar
 import com.apptolast.greenhouse.admin.presentation.ui.components.common.ErrorContent
 import com.apptolast.greenhouse.admin.presentation.ui.components.common.LoadingContent
+import com.apptolast.greenhouse.admin.presentation.ui.components.dialogs.AlertFormDialog
 import com.apptolast.greenhouse.admin.presentation.ui.components.dialogs.ClientFormDialog
 import com.apptolast.greenhouse.admin.presentation.ui.components.dialogs.ClientFormMode
 import com.apptolast.greenhouse.admin.presentation.ui.components.dialogs.DeleteConfirmationDialog
+import com.apptolast.greenhouse.admin.presentation.ui.components.dialogs.DeviceFormDialog
+import com.apptolast.greenhouse.admin.presentation.ui.components.dialogs.GreenhouseFormDialog
+import com.apptolast.greenhouse.admin.presentation.ui.components.dialogs.SectorFormDialog
+import com.apptolast.greenhouse.admin.presentation.ui.components.dialogs.SettingFormDialog
 import com.apptolast.greenhouse.admin.presentation.ui.components.dialogs.UserFormDialog
 import com.apptolast.greenhouse.admin.presentation.ui.theme.GreenhouseAdminTheme
 import com.apptolast.greenhouse.admin.presentation.viewmodel.ClientDetailEvent
@@ -48,12 +62,12 @@ import greenhouseadmin.composeapp.generated.resources.Res
 import greenhouseadmin.composeapp.generated.resources.app_name
 import greenhouseadmin.composeapp.generated.resources.breadcrumb_clients
 import greenhouseadmin.composeapp.generated.resources.error_unknown
+import greenhouseadmin.composeapp.generated.resources.new_alert
+import greenhouseadmin.composeapp.generated.resources.new_device
+import greenhouseadmin.composeapp.generated.resources.new_greenhouse
+import greenhouseadmin.composeapp.generated.resources.new_sector
+import greenhouseadmin.composeapp.generated.resources.new_setting
 import greenhouseadmin.composeapp.generated.resources.new_user
-import greenhouseadmin.composeapp.generated.resources.tab_alerts
-import greenhouseadmin.composeapp.generated.resources.tab_devices
-import greenhouseadmin.composeapp.generated.resources.tab_greenhouses
-import greenhouseadmin.composeapp.generated.resources.tab_sectors
-import greenhouseadmin.composeapp.generated.resources.tab_settings
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
@@ -208,6 +222,127 @@ private fun ClientDetailScreenContent(
             onDismiss = { onEvent(ClientDetailEvent.OnCancelDeleteUser) }
         )
     }
+
+    // Greenhouse Form Dialog
+    if (uiState.showGreenhouseFormDialog) {
+        GreenhouseFormDialog(
+            mode = uiState.greenhouseFormMode,
+            isSubmitting = uiState.isSubmittingGreenhouse,
+            error = uiState.submitGreenhouseError,
+            onSubmit = { name, description, status ->
+                onEvent(ClientDetailEvent.OnSubmitGreenhouseForm(name, description, status))
+            },
+            onDismiss = { onEvent(ClientDetailEvent.OnDismissGreenhouseFormDialog) }
+        )
+    }
+
+    // Greenhouse Delete Confirmation Dialog
+    if (uiState.showDeleteGreenhouseConfirmation && uiState.greenhouseToDelete != null) {
+        DeleteConfirmationDialog(
+            clientName = uiState.greenhouseToDelete.name,
+            isDeleting = uiState.isDeletingGreenhouse,
+            error = uiState.deleteGreenhouseError,
+            onConfirm = { onEvent(ClientDetailEvent.OnConfirmDeleteGreenhouse) },
+            onDismiss = { onEvent(ClientDetailEvent.OnCancelDeleteGreenhouse) }
+        )
+    }
+
+    // Sector Form Dialog
+    if (uiState.showSectorFormDialog) {
+        SectorFormDialog(
+            mode = uiState.sectorFormMode,
+            greenhouses = uiState.greenhouses,
+            isSubmitting = uiState.isSubmittingSector,
+            error = uiState.submitSectorError,
+            onSubmit = { name, greenhouseId, greenhouseName, area ->
+                onEvent(ClientDetailEvent.OnSubmitSectorForm(name, greenhouseId, greenhouseName, area))
+            },
+            onDismiss = { onEvent(ClientDetailEvent.OnDismissSectorFormDialog) }
+        )
+    }
+
+    // Sector Delete Confirmation Dialog
+    if (uiState.showDeleteSectorConfirmation && uiState.sectorToDelete != null) {
+        DeleteConfirmationDialog(
+            clientName = uiState.sectorToDelete.name,
+            isDeleting = uiState.isDeletingSector,
+            error = uiState.deleteSectorError,
+            onConfirm = { onEvent(ClientDetailEvent.OnConfirmDeleteSector) },
+            onDismiss = { onEvent(ClientDetailEvent.OnCancelDeleteSector) }
+        )
+    }
+
+    // Device Form Dialog
+    if (uiState.showDeviceFormDialog) {
+        DeviceFormDialog(
+            mode = uiState.deviceFormMode,
+            isSubmitting = uiState.isSubmittingDevice,
+            error = uiState.submitDeviceError,
+            onSubmit = { name, type, status ->
+                onEvent(ClientDetailEvent.OnSubmitDeviceForm(name, type, status))
+            },
+            onDismiss = { onEvent(ClientDetailEvent.OnDismissDeviceFormDialog) }
+        )
+    }
+
+    // Device Delete Confirmation Dialog
+    if (uiState.showDeleteDeviceConfirmation && uiState.deviceToDelete != null) {
+        DeleteConfirmationDialog(
+            clientName = uiState.deviceToDelete.name,
+            isDeleting = uiState.isDeletingDevice,
+            error = uiState.deleteDeviceError,
+            onConfirm = { onEvent(ClientDetailEvent.OnConfirmDeleteDevice) },
+            onDismiss = { onEvent(ClientDetailEvent.OnCancelDeleteDevice) }
+        )
+    }
+
+    // Alert Form Dialog
+    if (uiState.showAlertFormDialog) {
+        AlertFormDialog(
+            mode = uiState.alertFormMode,
+            isSubmitting = uiState.isSubmittingAlert,
+            error = uiState.submitAlertError,
+            onSubmit = { title, severity, status ->
+                onEvent(ClientDetailEvent.OnSubmitAlertForm(title, severity, status))
+            },
+            onDismiss = { onEvent(ClientDetailEvent.OnDismissAlertFormDialog) }
+        )
+    }
+
+    // Alert Delete Confirmation Dialog
+    if (uiState.showDeleteAlertConfirmation && uiState.alertToDelete != null) {
+        DeleteConfirmationDialog(
+            clientName = uiState.alertToDelete.title,
+            isDeleting = uiState.isDeletingAlert,
+            error = uiState.deleteAlertError,
+            onConfirm = { onEvent(ClientDetailEvent.OnConfirmDeleteAlert) },
+            onDismiss = { onEvent(ClientDetailEvent.OnCancelDeleteAlert) }
+        )
+    }
+
+    // Setting Form Dialog
+    if (uiState.showSettingFormDialog) {
+        SettingFormDialog(
+            mode = uiState.settingFormMode,
+            isSubmitting = uiState.isSubmittingSetting,
+            error = uiState.submitSettingError,
+            onSubmit = { key, value, description ->
+                onEvent(ClientDetailEvent.OnSubmitSettingForm(key, value, description))
+            },
+            onDismiss = { onEvent(ClientDetailEvent.OnDismissSettingFormDialog) }
+        )
+    }
+
+    // Setting Delete Confirmation Dialog
+    if (uiState.showDeleteSettingConfirmation && uiState.settingToDelete != null) {
+        DeleteConfirmationDialog(
+            clientName = uiState.settingToDelete.key,
+            isDeleting = uiState.isDeletingSetting,
+            error = uiState.deleteSettingError,
+            onConfirm = { onEvent(ClientDetailEvent.OnConfirmDeleteSetting) },
+            onDismiss = { onEvent(ClientDetailEvent.OnCancelDeleteSetting) }
+        )
+    }
 }
 
 @Composable
@@ -220,8 +355,15 @@ private fun ClientDetailContent(
     val contentPadding = AdaptiveDimens.contentPadding()
     val windowInfo = LocalAppWindowInfo.current
 
-    // Show FAB on compact screens when on Users tab
-    val showFab = windowInfo.isCompact && uiState.selectedTab == ClientDetailTab.USERS
+    // Show FAB on compact screens when on tabs that support adding items
+    val showFab = windowInfo.isCompact && uiState.selectedTab in listOf(
+        ClientDetailTab.USERS,
+        ClientDetailTab.GREENHOUSES,
+        ClientDetailTab.SECTORS,
+        ClientDetailTab.DEVICES,
+        ClientDetailTab.ALERTS,
+        ClientDetailTab.SETTINGS
+    )
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -267,31 +409,116 @@ private fun ClientDetailContent(
                 }
 
                 ClientDetailTab.GREENHOUSES -> {
-                    ComingSoonContent(tabName = stringResource(Res.string.tab_greenhouses))
+                    ClientDetailGreenhousesTab(
+                        greenhouses = uiState.greenhouses,
+                        isLoading = uiState.isLoadingGreenhouses,
+                        error = uiState.greenhousesError,
+                        onAddGreenhouse = { onEvent(ClientDetailEvent.OnAddGreenhouseClicked) },
+                        onEditGreenhouse = { greenhouse -> onEvent(ClientDetailEvent.OnEditGreenhouseClicked(greenhouse)) },
+                        onDeleteGreenhouse = { greenhouse ->
+                            onEvent(
+                                ClientDetailEvent.OnDeleteGreenhouseClicked(
+                                    greenhouse
+                                )
+                            )
+                        },
+                        onRetry = { onEvent(ClientDetailEvent.LoadGreenhouses) }
+                    )
                 }
 
                 ClientDetailTab.SECTORS -> {
-                    ComingSoonContent(tabName = stringResource(Res.string.tab_sectors))
+                    ClientDetailSectorsTab(
+                        sectors = uiState.sectors,
+                        isLoading = uiState.isLoadingSectors,
+                        error = uiState.sectorsError,
+                        onAddSector = { onEvent(ClientDetailEvent.OnAddSectorClicked) },
+                        onEditSector = { sector -> onEvent(ClientDetailEvent.OnEditSectorClicked(sector)) },
+                        onDeleteSector = { sector -> onEvent(ClientDetailEvent.OnDeleteSectorClicked(sector)) },
+                        onRetry = { onEvent(ClientDetailEvent.LoadSectors) }
+                    )
                 }
 
                 ClientDetailTab.DEVICES -> {
-                    ComingSoonContent(tabName = stringResource(Res.string.tab_devices))
+                    ClientDetailDevicesTab(
+                        devices = uiState.devices,
+                        isLoading = uiState.isLoadingDevices,
+                        error = uiState.devicesError,
+                        onAddDevice = { onEvent(ClientDetailEvent.OnAddDeviceClicked) },
+                        onEditDevice = { device -> onEvent(ClientDetailEvent.OnEditDeviceClicked(device)) },
+                        onDeleteDevice = { device -> onEvent(ClientDetailEvent.OnDeleteDeviceClicked(device)) },
+                        onRetry = { onEvent(ClientDetailEvent.LoadDevices) }
+                    )
                 }
 
                 ClientDetailTab.ALERTS -> {
-                    ComingSoonContent(tabName = stringResource(Res.string.tab_alerts))
+                    ClientDetailAlertsTab(
+                        alerts = uiState.alerts,
+                        isLoading = uiState.isLoadingAlerts,
+                        error = uiState.alertsError,
+                        onAddAlert = { onEvent(ClientDetailEvent.OnAddAlertClicked) },
+                        onEditAlert = { alert -> onEvent(ClientDetailEvent.OnEditAlertClicked(alert)) },
+                        onDeleteAlert = { alert -> onEvent(ClientDetailEvent.OnDeleteAlertClicked(alert)) },
+                        onRetry = { onEvent(ClientDetailEvent.LoadAlerts) }
+                    )
                 }
 
                 ClientDetailTab.SETTINGS -> {
-                    ComingSoonContent(tabName = stringResource(Res.string.tab_settings))
+                    ClientDetailSettingsTab(
+                        settings = uiState.settings,
+                        isLoading = uiState.isLoadingSettings,
+                        error = uiState.settingsError,
+                        onAddSetting = { onEvent(ClientDetailEvent.OnAddSettingClicked) },
+                        onEditSetting = { setting -> onEvent(ClientDetailEvent.OnEditSettingClicked(setting)) },
+                        onDeleteSetting = { setting -> onEvent(ClientDetailEvent.OnDeleteSettingClicked(setting)) },
+                        onRetry = { onEvent(ClientDetailEvent.LoadSettings) }
+                    )
                 }
             }
         }
 
-        // FAB for adding users on compact screens
+        // FAB for adding items on compact screens
         if (showFab) {
+            val fabContentDescription = when (uiState.selectedTab) {
+                ClientDetailTab.USERS -> stringResource(Res.string.new_user)
+                ClientDetailTab.GREENHOUSES -> stringResource(Res.string.new_greenhouse)
+                ClientDetailTab.SECTORS -> stringResource(Res.string.new_sector)
+                ClientDetailTab.DEVICES -> stringResource(Res.string.new_device)
+                ClientDetailTab.ALERTS -> stringResource(Res.string.new_alert)
+                ClientDetailTab.SETTINGS -> stringResource(Res.string.new_setting)
+                else -> ""
+            }
+            val fabOnClick: () -> Unit = when (uiState.selectedTab) {
+                ClientDetailTab.USERS -> {
+                    { onEvent(ClientDetailEvent.OnAddUserClicked) }
+                }
+
+                ClientDetailTab.GREENHOUSES -> {
+                    { onEvent(ClientDetailEvent.OnAddGreenhouseClicked) }
+                }
+
+                ClientDetailTab.SECTORS -> {
+                    { onEvent(ClientDetailEvent.OnAddSectorClicked) }
+                }
+
+                ClientDetailTab.DEVICES -> {
+                    { onEvent(ClientDetailEvent.OnAddDeviceClicked) }
+                }
+
+                ClientDetailTab.ALERTS -> {
+                    { onEvent(ClientDetailEvent.OnAddAlertClicked) }
+                }
+
+                ClientDetailTab.SETTINGS -> {
+                    { onEvent(ClientDetailEvent.OnAddSettingClicked) }
+                }
+
+                else -> {
+                    {}
+                }
+            }
+
             FloatingActionButton(
-                onClick = { onEvent(ClientDetailEvent.OnAddUserClicked) },
+                onClick = fabOnClick,
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
                     .padding(16.dp),
@@ -300,7 +527,7 @@ private fun ClientDetailContent(
             ) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = stringResource(Res.string.new_user)
+                    contentDescription = fabContentDescription
                 )
             }
         }
@@ -337,6 +564,47 @@ private object ClientDetailScreenPreviewData {
             clientId = "12345"
         )
     )
+
+    val sampleGreenhouses = listOf(
+        Greenhouse(
+            id = "1",
+            name = "Invernadero Principal",
+            description = "Produccion de tomates y pimientos",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "12345"
+        ),
+        Greenhouse(
+            id = "2",
+            name = "Invernadero Norte",
+            description = "Cultivo de lechugas hidroponicas",
+            status = GreenhouseStatus.ACTIVE,
+            clientId = "12345"
+        )
+    )
+
+    val sampleDevices = listOf(
+        Device(
+            id = "1",
+            name = "Sensor Temperatura A1",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "12345"
+        ),
+        Device(
+            id = "2",
+            name = "Valvula Riego Norte",
+            type = DeviceType.ACTUATOR,
+            status = DeviceStatus.ONLINE,
+            clientId = "12345"
+        ),
+        Device(
+            id = "3",
+            name = "Sensor CO2 B2",
+            type = DeviceType.SENSOR,
+            status = DeviceStatus.OFFLINE,
+            clientId = "12345"
+        )
+    )
 }
 
 @Preview
@@ -368,6 +636,44 @@ private fun ClientDetailScreenContentUsersTabPreview() {
                     client = ClientDetailScreenPreviewData.sampleClient,
                     selectedTab = ClientDetailTab.USERS,
                     users = ClientDetailScreenPreviewData.sampleUsers
+                ),
+                onEvent = {},
+                onNavigateBack = {}
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailScreenContentGreenhousesTabPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailScreenContent(
+                uiState = ClientDetailUiState(
+                    isLoading = false,
+                    client = ClientDetailScreenPreviewData.sampleClient,
+                    selectedTab = ClientDetailTab.GREENHOUSES,
+                    greenhouses = ClientDetailScreenPreviewData.sampleGreenhouses
+                ),
+                onEvent = {},
+                onNavigateBack = {}
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ClientDetailScreenContentDevicesTabPreview() {
+    GreenhouseAdminTheme {
+        ProvideAppWindowInfo {
+            ClientDetailScreenContent(
+                uiState = ClientDetailUiState(
+                    isLoading = false,
+                    client = ClientDetailScreenPreviewData.sampleClient,
+                    selectedTab = ClientDetailTab.DEVICES,
+                    devices = ClientDetailScreenPreviewData.sampleDevices
                 ),
                 onEvent = {},
                 onNavigateBack = {}

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/viewmodel/ClientDetailEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/viewmodel/ClientDetailEvent.kt
@@ -1,6 +1,16 @@
 package com.apptolast.greenhouse.admin.presentation.viewmodel
 
+import com.apptolast.greenhouse.admin.data.model.Alert
+import com.apptolast.greenhouse.admin.data.model.AlertSeverity
+import com.apptolast.greenhouse.admin.data.model.AlertStatus
 import com.apptolast.greenhouse.admin.data.model.ClientStatus
+import com.apptolast.greenhouse.admin.data.model.Device
+import com.apptolast.greenhouse.admin.data.model.DeviceStatus
+import com.apptolast.greenhouse.admin.data.model.DeviceType
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
+import com.apptolast.greenhouse.admin.data.model.GreenhouseStatus
+import com.apptolast.greenhouse.admin.data.model.Sector
+import com.apptolast.greenhouse.admin.data.model.Setting
 import com.apptolast.greenhouse.admin.data.model.User
 
 /**
@@ -125,5 +135,236 @@ sealed interface ClientDetailEvent {
         val name: String,
         val email: String,
         val phone: String
+    ) : ClientDetailEvent
+
+    // === Greenhouses Tab Events ===
+
+    /**
+     * Load greenhouses for the current client.
+     */
+    data object LoadGreenhouses : ClientDetailEvent
+
+    /**
+     * User clicked "Add Greenhouse" button.
+     */
+    data object OnAddGreenhouseClicked : ClientDetailEvent
+
+    /**
+     * User clicked edit on a specific greenhouse.
+     */
+    data class OnEditGreenhouseClicked(val greenhouse: Greenhouse) : ClientDetailEvent
+
+    /**
+     * User clicked delete on a specific greenhouse.
+     */
+    data class OnDeleteGreenhouseClicked(val greenhouse: Greenhouse) : ClientDetailEvent
+
+    /**
+     * User confirmed delete action for a greenhouse.
+     */
+    data object OnConfirmDeleteGreenhouse : ClientDetailEvent
+
+    /**
+     * User cancelled delete action for a greenhouse.
+     */
+    data object OnCancelDeleteGreenhouse : ClientDetailEvent
+
+    /**
+     * User dismissed the greenhouse form dialog.
+     */
+    data object OnDismissGreenhouseFormDialog : ClientDetailEvent
+
+    /**
+     * User submitted the greenhouse form (create or edit).
+     */
+    data class OnSubmitGreenhouseForm(
+        val name: String,
+        val description: String,
+        val status: GreenhouseStatus
+    ) : ClientDetailEvent
+
+    // === Sectors Tab Events ===
+
+    /**
+     * Load sectors for the current client.
+     */
+    data object LoadSectors : ClientDetailEvent
+
+    /**
+     * User clicked "Add Sector" button.
+     */
+    data object OnAddSectorClicked : ClientDetailEvent
+
+    /**
+     * User clicked edit on a specific sector.
+     */
+    data class OnEditSectorClicked(val sector: Sector) : ClientDetailEvent
+
+    /**
+     * User clicked delete on a specific sector.
+     */
+    data class OnDeleteSectorClicked(val sector: Sector) : ClientDetailEvent
+
+    /**
+     * User confirmed delete action for a sector.
+     */
+    data object OnConfirmDeleteSector : ClientDetailEvent
+
+    /**
+     * User cancelled delete action for a sector.
+     */
+    data object OnCancelDeleteSector : ClientDetailEvent
+
+    /**
+     * User dismissed the sector form dialog.
+     */
+    data object OnDismissSectorFormDialog : ClientDetailEvent
+
+    /**
+     * User submitted the sector form (create or edit).
+     */
+    data class OnSubmitSectorForm(
+        val name: String,
+        val greenhouseId: String,
+        val greenhouseName: String,
+        val area: Double
+    ) : ClientDetailEvent
+
+    // === Devices Tab Events ===
+
+    /**
+     * Load devices for the current client.
+     */
+    data object LoadDevices : ClientDetailEvent
+
+    /**
+     * User clicked "Add Device" button.
+     */
+    data object OnAddDeviceClicked : ClientDetailEvent
+
+    /**
+     * User clicked edit on a specific device.
+     */
+    data class OnEditDeviceClicked(val device: Device) : ClientDetailEvent
+
+    /**
+     * User clicked delete on a specific device.
+     */
+    data class OnDeleteDeviceClicked(val device: Device) : ClientDetailEvent
+
+    /**
+     * User confirmed delete action for a device.
+     */
+    data object OnConfirmDeleteDevice : ClientDetailEvent
+
+    /**
+     * User cancelled delete action for a device.
+     */
+    data object OnCancelDeleteDevice : ClientDetailEvent
+
+    /**
+     * User dismissed the device form dialog.
+     */
+    data object OnDismissDeviceFormDialog : ClientDetailEvent
+
+    /**
+     * User submitted the device form (create or edit).
+     */
+    data class OnSubmitDeviceForm(
+        val name: String,
+        val type: DeviceType,
+        val status: DeviceStatus
+    ) : ClientDetailEvent
+
+    // === Alerts Tab Events ===
+
+    /**
+     * Load alerts for the current client.
+     */
+    data object LoadAlerts : ClientDetailEvent
+
+    /**
+     * User clicked "Add Alert" button.
+     */
+    data object OnAddAlertClicked : ClientDetailEvent
+
+    /**
+     * User clicked edit on a specific alert.
+     */
+    data class OnEditAlertClicked(val alert: Alert) : ClientDetailEvent
+
+    /**
+     * User clicked delete on a specific alert.
+     */
+    data class OnDeleteAlertClicked(val alert: Alert) : ClientDetailEvent
+
+    /**
+     * User confirmed delete action for an alert.
+     */
+    data object OnConfirmDeleteAlert : ClientDetailEvent
+
+    /**
+     * User cancelled delete action for an alert.
+     */
+    data object OnCancelDeleteAlert : ClientDetailEvent
+
+    /**
+     * User dismissed the alert form dialog.
+     */
+    data object OnDismissAlertFormDialog : ClientDetailEvent
+
+    /**
+     * User submitted the alert form (create or edit).
+     */
+    data class OnSubmitAlertForm(
+        val title: String,
+        val severity: AlertSeverity,
+        val status: AlertStatus
+    ) : ClientDetailEvent
+
+    // === Settings Tab Events ===
+
+    /**
+     * Load settings for the current client.
+     */
+    data object LoadSettings : ClientDetailEvent
+
+    /**
+     * User clicked "Add Setting" button.
+     */
+    data object OnAddSettingClicked : ClientDetailEvent
+
+    /**
+     * User clicked edit on a specific setting.
+     */
+    data class OnEditSettingClicked(val setting: Setting) : ClientDetailEvent
+
+    /**
+     * User clicked delete on a specific setting.
+     */
+    data class OnDeleteSettingClicked(val setting: Setting) : ClientDetailEvent
+
+    /**
+     * User confirmed delete action for a setting.
+     */
+    data object OnConfirmDeleteSetting : ClientDetailEvent
+
+    /**
+     * User cancelled delete action for a setting.
+     */
+    data object OnCancelDeleteSetting : ClientDetailEvent
+
+    /**
+     * User dismissed the setting form dialog.
+     */
+    data object OnDismissSettingFormDialog : ClientDetailEvent
+
+    /**
+     * User submitted the setting form (create or edit).
+     */
+    data class OnSubmitSettingForm(
+        val key: String,
+        val value: String,
+        val description: String
     ) : ClientDetailEvent
 }

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/viewmodel/ClientDetailUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/viewmodel/ClientDetailUiState.kt
@@ -1,7 +1,12 @@
 package com.apptolast.greenhouse.admin.presentation.viewmodel
 
+import com.apptolast.greenhouse.admin.data.model.Alert
 import com.apptolast.greenhouse.admin.data.model.Client
+import com.apptolast.greenhouse.admin.data.model.Device
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
 import com.apptolast.greenhouse.admin.data.model.MenuItem
+import com.apptolast.greenhouse.admin.data.model.Sector
+import com.apptolast.greenhouse.admin.data.model.Setting
 import com.apptolast.greenhouse.admin.data.model.User
 
 /**
@@ -53,7 +58,92 @@ data class ClientDetailUiState(
     val showDeleteUserConfirmation: Boolean = false,
     val userToDelete: User? = null,
     val isDeletingUser: Boolean = false,
-    val deleteUserError: String? = null
+    val deleteUserError: String? = null,
+
+    // Greenhouses tab state
+    val greenhouses: List<Greenhouse> = emptyList(),
+    val isLoadingGreenhouses: Boolean = false,
+    val greenhousesError: String? = null,
+
+    // Greenhouse form dialog states
+    val showGreenhouseFormDialog: Boolean = false,
+    val greenhouseFormMode: GreenhouseFormMode = GreenhouseFormMode.Create,
+    val isSubmittingGreenhouse: Boolean = false,
+    val submitGreenhouseError: String? = null,
+
+    // Greenhouse delete dialog states
+    val showDeleteGreenhouseConfirmation: Boolean = false,
+    val greenhouseToDelete: Greenhouse? = null,
+    val isDeletingGreenhouse: Boolean = false,
+    val deleteGreenhouseError: String? = null,
+
+    // Sectors tab state
+    val sectors: List<Sector> = emptyList(),
+    val isLoadingSectors: Boolean = false,
+    val sectorsError: String? = null,
+
+    // Sector form dialog states
+    val showSectorFormDialog: Boolean = false,
+    val sectorFormMode: SectorFormMode = SectorFormMode.Create,
+    val isSubmittingSector: Boolean = false,
+    val submitSectorError: String? = null,
+
+    // Sector delete dialog states
+    val showDeleteSectorConfirmation: Boolean = false,
+    val sectorToDelete: Sector? = null,
+    val isDeletingSector: Boolean = false,
+    val deleteSectorError: String? = null,
+
+    // Devices tab state
+    val devices: List<Device> = emptyList(),
+    val isLoadingDevices: Boolean = false,
+    val devicesError: String? = null,
+
+    // Device form dialog states
+    val showDeviceFormDialog: Boolean = false,
+    val deviceFormMode: DeviceFormMode = DeviceFormMode.Create,
+    val isSubmittingDevice: Boolean = false,
+    val submitDeviceError: String? = null,
+
+    // Device delete dialog states
+    val showDeleteDeviceConfirmation: Boolean = false,
+    val deviceToDelete: Device? = null,
+    val isDeletingDevice: Boolean = false,
+    val deleteDeviceError: String? = null,
+
+    // Alerts tab state
+    val alerts: List<Alert> = emptyList(),
+    val isLoadingAlerts: Boolean = false,
+    val alertsError: String? = null,
+
+    // Alert form dialog states
+    val showAlertFormDialog: Boolean = false,
+    val alertFormMode: AlertFormMode = AlertFormMode.Create,
+    val isSubmittingAlert: Boolean = false,
+    val submitAlertError: String? = null,
+
+    // Alert delete dialog states
+    val showDeleteAlertConfirmation: Boolean = false,
+    val alertToDelete: Alert? = null,
+    val isDeletingAlert: Boolean = false,
+    val deleteAlertError: String? = null,
+
+    // Settings tab state
+    val settings: List<Setting> = emptyList(),
+    val isLoadingSettings: Boolean = false,
+    val settingsError: String? = null,
+
+    // Setting form dialog states
+    val showSettingFormDialog: Boolean = false,
+    val settingFormMode: SettingFormMode = SettingFormMode.Create,
+    val isSubmittingSetting: Boolean = false,
+    val submitSettingError: String? = null,
+
+    // Setting delete dialog states
+    val showDeleteSettingConfirmation: Boolean = false,
+    val settingToDelete: Setting? = null,
+    val isDeletingSetting: Boolean = false,
+    val deleteSettingError: String? = null
 ) {
     /**
      * Returns true if in error state with no content.
@@ -87,4 +177,44 @@ enum class ClientDetailTab {
 sealed interface UserFormMode {
     data object Create : UserFormMode
     data class Edit(val user: User) : UserFormMode
+}
+
+/**
+ * Mode for the greenhouse form dialog.
+ */
+sealed interface GreenhouseFormMode {
+    data object Create : GreenhouseFormMode
+    data class Edit(val greenhouse: Greenhouse) : GreenhouseFormMode
+}
+
+/**
+ * Mode for the sector form dialog.
+ */
+sealed interface SectorFormMode {
+    data object Create : SectorFormMode
+    data class Edit(val sector: Sector) : SectorFormMode
+}
+
+/**
+ * Mode for the device form dialog.
+ */
+sealed interface DeviceFormMode {
+    data object Create : DeviceFormMode
+    data class Edit(val device: Device) : DeviceFormMode
+}
+
+/**
+ * Mode for the alert form dialog.
+ */
+sealed interface AlertFormMode {
+    data object Create : AlertFormMode
+    data class Edit(val alert: Alert) : AlertFormMode
+}
+
+/**
+ * Mode for the setting form dialog.
+ */
+sealed interface SettingFormMode {
+    data object Create : SettingFormMode
+    data class Edit(val setting: Setting) : SettingFormMode
 }

--- a/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/viewmodel/ClientDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/apptolast/greenhouse/admin/presentation/viewmodel/ClientDetailViewModel.kt
@@ -2,16 +2,32 @@ package com.apptolast.greenhouse.admin.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.apptolast.greenhouse.admin.data.model.Alert
+import com.apptolast.greenhouse.admin.data.model.AlertSeverity
+import com.apptolast.greenhouse.admin.data.model.AlertStatus
 import com.apptolast.greenhouse.admin.data.model.ClientStatus
+import com.apptolast.greenhouse.admin.data.model.Device
+import com.apptolast.greenhouse.admin.data.model.DeviceStatus
+import com.apptolast.greenhouse.admin.data.model.DeviceType
+import com.apptolast.greenhouse.admin.data.model.Greenhouse
+import com.apptolast.greenhouse.admin.data.model.GreenhouseStatus
+import com.apptolast.greenhouse.admin.data.model.Sector
+import com.apptolast.greenhouse.admin.data.model.Setting
 import com.apptolast.greenhouse.admin.data.model.User
+import com.apptolast.greenhouse.admin.domain.repository.AlertsRepository
 import com.apptolast.greenhouse.admin.domain.repository.ClientsRepository
 import com.apptolast.greenhouse.admin.domain.repository.DashboardRepository
+import com.apptolast.greenhouse.admin.domain.repository.DevicesRepository
+import com.apptolast.greenhouse.admin.domain.repository.GreenhousesRepository
+import com.apptolast.greenhouse.admin.domain.repository.SectorsRepository
+import com.apptolast.greenhouse.admin.domain.repository.SettingsRepository
 import com.apptolast.greenhouse.admin.domain.repository.UsersRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
 
 /**
  * ViewModel for the Client Detail screen following MVVM+MVI pattern.
@@ -20,7 +36,12 @@ class ClientDetailViewModel(
     private val clientId: String,
     private val clientsRepository: ClientsRepository,
     private val dashboardRepository: DashboardRepository,
-    private val usersRepository: UsersRepository
+    private val usersRepository: UsersRepository,
+    private val greenhousesRepository: GreenhousesRepository,
+    private val sectorsRepository: SectorsRepository,
+    private val devicesRepository: DevicesRepository,
+    private val alertsRepository: AlertsRepository,
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ClientDetailUiState())
@@ -89,6 +110,65 @@ class ClientDetailViewModel(
             is ClientDetailEvent.OnCancelDeleteUser -> cancelDeleteUser()
             is ClientDetailEvent.OnDismissUserFormDialog -> dismissUserFormDialog()
             is ClientDetailEvent.OnSubmitUserForm -> submitUserForm(event.name, event.email, event.phone)
+
+            // Greenhouses events
+            is ClientDetailEvent.LoadGreenhouses -> loadGreenhouses()
+            is ClientDetailEvent.OnAddGreenhouseClicked -> showGreenhouseFormDialog(GreenhouseFormMode.Create)
+            is ClientDetailEvent.OnEditGreenhouseClicked -> showGreenhouseFormDialog(GreenhouseFormMode.Edit(event.greenhouse))
+            is ClientDetailEvent.OnDeleteGreenhouseClicked -> showDeleteGreenhouseConfirmation(event.greenhouse)
+            is ClientDetailEvent.OnConfirmDeleteGreenhouse -> confirmDeleteGreenhouse()
+            is ClientDetailEvent.OnCancelDeleteGreenhouse -> cancelDeleteGreenhouse()
+            is ClientDetailEvent.OnDismissGreenhouseFormDialog -> dismissGreenhouseFormDialog()
+            is ClientDetailEvent.OnSubmitGreenhouseForm -> submitGreenhouseForm(
+                event.name,
+                event.description,
+                event.status
+            )
+
+            // Sectors events
+            is ClientDetailEvent.LoadSectors -> loadSectors()
+            is ClientDetailEvent.OnAddSectorClicked -> showSectorFormDialog(SectorFormMode.Create)
+            is ClientDetailEvent.OnEditSectorClicked -> showSectorFormDialog(SectorFormMode.Edit(event.sector))
+            is ClientDetailEvent.OnDeleteSectorClicked -> showDeleteSectorConfirmation(event.sector)
+            is ClientDetailEvent.OnConfirmDeleteSector -> confirmDeleteSector()
+            is ClientDetailEvent.OnCancelDeleteSector -> cancelDeleteSector()
+            is ClientDetailEvent.OnDismissSectorFormDialog -> dismissSectorFormDialog()
+            is ClientDetailEvent.OnSubmitSectorForm -> submitSectorForm(
+                event.name,
+                event.greenhouseId,
+                event.greenhouseName,
+                event.area
+            )
+
+            // Devices events
+            is ClientDetailEvent.LoadDevices -> loadDevices()
+            is ClientDetailEvent.OnAddDeviceClicked -> showDeviceFormDialog(DeviceFormMode.Create)
+            is ClientDetailEvent.OnEditDeviceClicked -> showDeviceFormDialog(DeviceFormMode.Edit(event.device))
+            is ClientDetailEvent.OnDeleteDeviceClicked -> showDeleteDeviceConfirmation(event.device)
+            is ClientDetailEvent.OnConfirmDeleteDevice -> confirmDeleteDevice()
+            is ClientDetailEvent.OnCancelDeleteDevice -> cancelDeleteDevice()
+            is ClientDetailEvent.OnDismissDeviceFormDialog -> dismissDeviceFormDialog()
+            is ClientDetailEvent.OnSubmitDeviceForm -> submitDeviceForm(event.name, event.type, event.status)
+
+            // Alerts events
+            is ClientDetailEvent.LoadAlerts -> loadAlerts()
+            is ClientDetailEvent.OnAddAlertClicked -> showAlertFormDialog(AlertFormMode.Create)
+            is ClientDetailEvent.OnEditAlertClicked -> showAlertFormDialog(AlertFormMode.Edit(event.alert))
+            is ClientDetailEvent.OnDeleteAlertClicked -> showDeleteAlertConfirmation(event.alert)
+            is ClientDetailEvent.OnConfirmDeleteAlert -> confirmDeleteAlert()
+            is ClientDetailEvent.OnCancelDeleteAlert -> cancelDeleteAlert()
+            is ClientDetailEvent.OnDismissAlertFormDialog -> dismissAlertFormDialog()
+            is ClientDetailEvent.OnSubmitAlertForm -> submitAlertForm(event.title, event.severity, event.status)
+
+            // Settings events
+            is ClientDetailEvent.LoadSettings -> loadSettings()
+            is ClientDetailEvent.OnAddSettingClicked -> showSettingFormDialog(SettingFormMode.Create)
+            is ClientDetailEvent.OnEditSettingClicked -> showSettingFormDialog(SettingFormMode.Edit(event.setting))
+            is ClientDetailEvent.OnDeleteSettingClicked -> showDeleteSettingConfirmation(event.setting)
+            is ClientDetailEvent.OnConfirmDeleteSetting -> confirmDeleteSetting()
+            is ClientDetailEvent.OnCancelDeleteSetting -> cancelDeleteSetting()
+            is ClientDetailEvent.OnDismissSettingFormDialog -> dismissSettingFormDialog()
+            is ClientDetailEvent.OnSubmitSettingForm -> submitSettingForm(event.key, event.value, event.description)
         }
     }
 
@@ -119,9 +199,44 @@ class ClientDetailViewModel(
 
     private fun selectTab(tab: ClientDetailTab) {
         _uiState.update { it.copy(selectedTab = tab) }
-        // Load users when USERS tab is selected and not already loaded
-        if (tab == ClientDetailTab.USERS && _uiState.value.users.isEmpty() && !_uiState.value.isLoadingUsers) {
-            loadUsers()
+        // Load data when tab is selected and not already loaded
+        when (tab) {
+            ClientDetailTab.USERS -> {
+                if (_uiState.value.users.isEmpty() && !_uiState.value.isLoadingUsers) {
+                    loadUsers()
+                }
+            }
+
+            ClientDetailTab.GREENHOUSES -> {
+                if (_uiState.value.greenhouses.isEmpty() && !_uiState.value.isLoadingGreenhouses) {
+                    loadGreenhouses()
+                }
+            }
+
+            ClientDetailTab.SECTORS -> {
+                if (_uiState.value.sectors.isEmpty() && !_uiState.value.isLoadingSectors) {
+                    loadSectors()
+                }
+                // Also load greenhouses for the dropdown if not already loaded
+                if (_uiState.value.greenhouses.isEmpty() && !_uiState.value.isLoadingGreenhouses) {
+                    loadGreenhouses()
+                }
+            }
+
+            ClientDetailTab.DEVICES -> {
+                if (_uiState.value.devices.isEmpty() && !_uiState.value.isLoadingDevices) {
+                    loadDevices()
+                }
+            }
+
+            ClientDetailTab.ALERTS -> {
+                if (_uiState.value.alerts.isEmpty() && !_uiState.value.isLoadingAlerts) {
+                    loadAlerts()
+                }
+            }
+
+            else -> { /* No lazy loading for other tabs yet */
+            }
         }
     }
 
@@ -393,6 +508,726 @@ class ClientDetailViewModel(
                         it.copy(
                             isDeletingUser = false,
                             deleteUserError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    // === Greenhouses Tab Methods ===
+
+    private fun loadGreenhouses() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingGreenhouses = true, greenhousesError = null) }
+
+            greenhousesRepository.getGreenhousesByClientId(clientId)
+                .onSuccess { greenhouses ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingGreenhouses = false,
+                            greenhouses = greenhouses
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingGreenhouses = false,
+                            greenhousesError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showGreenhouseFormDialog(mode: GreenhouseFormMode) {
+        _uiState.update {
+            it.copy(
+                showGreenhouseFormDialog = true,
+                greenhouseFormMode = mode,
+                submitGreenhouseError = null
+            )
+        }
+    }
+
+    private fun dismissGreenhouseFormDialog() {
+        _uiState.update {
+            it.copy(
+                showGreenhouseFormDialog = false,
+                isSubmittingGreenhouse = false,
+                submitGreenhouseError = null
+            )
+        }
+    }
+
+    private fun submitGreenhouseForm(name: String, description: String, status: GreenhouseStatus) {
+        val mode = _uiState.value.greenhouseFormMode
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmittingGreenhouse = true, submitGreenhouseError = null) }
+
+            val result = when (mode) {
+                is GreenhouseFormMode.Create -> {
+                    val newGreenhouse = Greenhouse(
+                        id = "",
+                        name = name.trim(),
+                        description = description.trim(),
+                        status = status,
+                        clientId = clientId
+                    )
+                    greenhousesRepository.createGreenhouse(newGreenhouse)
+                }
+
+                is GreenhouseFormMode.Edit -> {
+                    val updatedGreenhouse = mode.greenhouse.copy(
+                        name = name.trim(),
+                        description = description.trim(),
+                        status = status
+                    )
+                    greenhousesRepository.updateGreenhouse(updatedGreenhouse)
+                }
+            }
+
+            result
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            showGreenhouseFormDialog = false,
+                            isSubmittingGreenhouse = false
+                        )
+                    }
+                    loadGreenhouses() // Reload greenhouses from repository to ensure sync
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isSubmittingGreenhouse = false,
+                            submitGreenhouseError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showDeleteGreenhouseConfirmation(greenhouse: Greenhouse) {
+        _uiState.update {
+            it.copy(
+                showDeleteGreenhouseConfirmation = true,
+                greenhouseToDelete = greenhouse,
+                deleteGreenhouseError = null
+            )
+        }
+    }
+
+    private fun cancelDeleteGreenhouse() {
+        _uiState.update {
+            it.copy(
+                showDeleteGreenhouseConfirmation = false,
+                greenhouseToDelete = null,
+                deleteGreenhouseError = null
+            )
+        }
+    }
+
+    private fun confirmDeleteGreenhouse() {
+        val greenhouse = _uiState.value.greenhouseToDelete ?: return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDeletingGreenhouse = true, deleteGreenhouseError = null) }
+
+            greenhousesRepository.deleteGreenhouse(greenhouse.id)
+                .onSuccess {
+                    _uiState.update { state ->
+                        state.copy(
+                            greenhouses = state.greenhouses.filter { it.id != greenhouse.id },
+                            showDeleteGreenhouseConfirmation = false,
+                            greenhouseToDelete = null,
+                            isDeletingGreenhouse = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isDeletingGreenhouse = false,
+                            deleteGreenhouseError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    // === Sectors Tab Methods ===
+
+    private fun loadSectors() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingSectors = true, sectorsError = null) }
+
+            sectorsRepository.getSectorsByClientId(clientId)
+                .onSuccess { sectors ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingSectors = false,
+                            sectors = sectors
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingSectors = false,
+                            sectorsError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showSectorFormDialog(mode: SectorFormMode) {
+        _uiState.update {
+            it.copy(
+                showSectorFormDialog = true,
+                sectorFormMode = mode,
+                submitSectorError = null
+            )
+        }
+    }
+
+    private fun dismissSectorFormDialog() {
+        _uiState.update {
+            it.copy(
+                showSectorFormDialog = false,
+                isSubmittingSector = false,
+                submitSectorError = null
+            )
+        }
+    }
+
+    private fun submitSectorForm(name: String, greenhouseId: String, greenhouseName: String, area: Double) {
+        val mode = _uiState.value.sectorFormMode
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmittingSector = true, submitSectorError = null) }
+
+            val result = when (mode) {
+                is SectorFormMode.Create -> {
+                    val newSector = Sector(
+                        id = "",
+                        name = name.trim(),
+                        greenhouseId = greenhouseId,
+                        greenhouseName = greenhouseName,
+                        area = area,
+                        clientId = clientId
+                    )
+                    sectorsRepository.createSector(newSector)
+                }
+
+                is SectorFormMode.Edit -> {
+                    val updatedSector = mode.sector.copy(
+                        name = name.trim(),
+                        greenhouseId = greenhouseId,
+                        greenhouseName = greenhouseName,
+                        area = area
+                    )
+                    sectorsRepository.updateSector(updatedSector)
+                }
+            }
+
+            result
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            showSectorFormDialog = false,
+                            isSubmittingSector = false
+                        )
+                    }
+                    loadSectors() // Reload sectors from repository to ensure sync
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isSubmittingSector = false,
+                            submitSectorError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showDeleteSectorConfirmation(sector: Sector) {
+        _uiState.update {
+            it.copy(
+                showDeleteSectorConfirmation = true,
+                sectorToDelete = sector,
+                deleteSectorError = null
+            )
+        }
+    }
+
+    private fun cancelDeleteSector() {
+        _uiState.update {
+            it.copy(
+                showDeleteSectorConfirmation = false,
+                sectorToDelete = null,
+                deleteSectorError = null
+            )
+        }
+    }
+
+    private fun confirmDeleteSector() {
+        val sector = _uiState.value.sectorToDelete ?: return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDeletingSector = true, deleteSectorError = null) }
+
+            sectorsRepository.deleteSector(sector.id)
+                .onSuccess {
+                    _uiState.update { state ->
+                        state.copy(
+                            sectors = state.sectors.filter { it.id != sector.id },
+                            showDeleteSectorConfirmation = false,
+                            sectorToDelete = null,
+                            isDeletingSector = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isDeletingSector = false,
+                            deleteSectorError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    // === Devices Tab Methods ===
+
+    private fun loadDevices() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingDevices = true, devicesError = null) }
+
+            devicesRepository.getDevicesByClientId(clientId)
+                .onSuccess { devices ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingDevices = false,
+                            devices = devices
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingDevices = false,
+                            devicesError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showDeviceFormDialog(mode: DeviceFormMode) {
+        _uiState.update {
+            it.copy(
+                showDeviceFormDialog = true,
+                deviceFormMode = mode,
+                submitDeviceError = null
+            )
+        }
+    }
+
+    private fun dismissDeviceFormDialog() {
+        _uiState.update {
+            it.copy(
+                showDeviceFormDialog = false,
+                isSubmittingDevice = false,
+                submitDeviceError = null
+            )
+        }
+    }
+
+    private fun submitDeviceForm(name: String, type: DeviceType, status: DeviceStatus) {
+        val mode = _uiState.value.deviceFormMode
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmittingDevice = true, submitDeviceError = null) }
+
+            val result = when (mode) {
+                is DeviceFormMode.Create -> {
+                    val newDevice = Device(
+                        id = "",
+                        name = name.trim(),
+                        type = type,
+                        status = status,
+                        clientId = clientId
+                    )
+                    devicesRepository.createDevice(newDevice)
+                }
+
+                is DeviceFormMode.Edit -> {
+                    val updatedDevice = mode.device.copy(
+                        name = name.trim(),
+                        type = type,
+                        status = status
+                    )
+                    devicesRepository.updateDevice(updatedDevice)
+                }
+            }
+
+            result
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            showDeviceFormDialog = false,
+                            isSubmittingDevice = false
+                        )
+                    }
+                    loadDevices() // Reload devices from repository to ensure sync
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isSubmittingDevice = false,
+                            submitDeviceError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showDeleteDeviceConfirmation(device: Device) {
+        _uiState.update {
+            it.copy(
+                showDeleteDeviceConfirmation = true,
+                deviceToDelete = device,
+                deleteDeviceError = null
+            )
+        }
+    }
+
+    private fun cancelDeleteDevice() {
+        _uiState.update {
+            it.copy(
+                showDeleteDeviceConfirmation = false,
+                deviceToDelete = null,
+                deleteDeviceError = null
+            )
+        }
+    }
+
+    private fun confirmDeleteDevice() {
+        val device = _uiState.value.deviceToDelete ?: return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDeletingDevice = true, deleteDeviceError = null) }
+
+            devicesRepository.deleteDevice(device.id)
+                .onSuccess {
+                    _uiState.update { state ->
+                        state.copy(
+                            devices = state.devices.filter { it.id != device.id },
+                            showDeleteDeviceConfirmation = false,
+                            deviceToDelete = null,
+                            isDeletingDevice = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isDeletingDevice = false,
+                            deleteDeviceError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    // === Alerts Tab Methods ===
+
+    private fun loadAlerts() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingAlerts = true, alertsError = null) }
+
+            alertsRepository.getAlertsByClientId(clientId)
+                .onSuccess { alerts ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingAlerts = false,
+                            alerts = alerts
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingAlerts = false,
+                            alertsError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showAlertFormDialog(mode: AlertFormMode) {
+        _uiState.update {
+            it.copy(
+                showAlertFormDialog = true,
+                alertFormMode = mode,
+                submitAlertError = null
+            )
+        }
+    }
+
+    private fun dismissAlertFormDialog() {
+        _uiState.update {
+            it.copy(
+                showAlertFormDialog = false,
+                isSubmittingAlert = false,
+                submitAlertError = null
+            )
+        }
+    }
+
+    private fun submitAlertForm(title: String, severity: AlertSeverity, status: AlertStatus) {
+        val mode = _uiState.value.alertFormMode
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmittingAlert = true, submitAlertError = null) }
+
+            val result = when (mode) {
+                is AlertFormMode.Create -> {
+                    val newAlert = Alert(
+                        id = "",
+                        title = title.trim(),
+                        severity = severity,
+                        status = status,
+                        createdAt = Clock.System.now().toEpochMilliseconds(),
+                        clientId = clientId
+                    )
+                    alertsRepository.createAlert(newAlert)
+                }
+
+                is AlertFormMode.Edit -> {
+                    val updatedAlert = mode.alert.copy(
+                        title = title.trim(),
+                        severity = severity,
+                        status = status
+                    )
+                    alertsRepository.updateAlert(updatedAlert)
+                }
+            }
+
+            result
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            showAlertFormDialog = false,
+                            isSubmittingAlert = false
+                        )
+                    }
+                    loadAlerts() // Reload alerts from repository to ensure sync
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isSubmittingAlert = false,
+                            submitAlertError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showDeleteAlertConfirmation(alert: Alert) {
+        _uiState.update {
+            it.copy(
+                showDeleteAlertConfirmation = true,
+                alertToDelete = alert,
+                deleteAlertError = null
+            )
+        }
+    }
+
+    private fun cancelDeleteAlert() {
+        _uiState.update {
+            it.copy(
+                showDeleteAlertConfirmation = false,
+                alertToDelete = null,
+                deleteAlertError = null
+            )
+        }
+    }
+
+    private fun confirmDeleteAlert() {
+        val alert = _uiState.value.alertToDelete ?: return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDeletingAlert = true, deleteAlertError = null) }
+
+            alertsRepository.deleteAlert(alert.id)
+                .onSuccess {
+                    _uiState.update { state ->
+                        state.copy(
+                            alerts = state.alerts.filter { it.id != alert.id },
+                            showDeleteAlertConfirmation = false,
+                            alertToDelete = null,
+                            isDeletingAlert = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isDeletingAlert = false,
+                            deleteAlertError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    // =============================================
+    // Settings Tab Handlers
+    // =============================================
+
+    private fun loadSettings() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingSettings = true, settingsError = null) }
+
+            settingsRepository.getSettingsByClientId(clientId)
+                .onSuccess { settings ->
+                    _uiState.update {
+                        it.copy(
+                            settings = settings,
+                            isLoadingSettings = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isLoadingSettings = false,
+                            settingsError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showSettingFormDialog(mode: SettingFormMode) {
+        _uiState.update {
+            it.copy(
+                showSettingFormDialog = true,
+                settingFormMode = mode,
+                isSubmittingSetting = false,
+                submitSettingError = null
+            )
+        }
+    }
+
+    private fun dismissSettingFormDialog() {
+        _uiState.update {
+            it.copy(
+                showSettingFormDialog = false,
+                isSubmittingSetting = false,
+                submitSettingError = null
+            )
+        }
+    }
+
+    private fun submitSettingForm(key: String, value: String, description: String) {
+        val mode = _uiState.value.settingFormMode
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmittingSetting = true, submitSettingError = null) }
+
+            val result = when (mode) {
+                is SettingFormMode.Create -> {
+                    val newSetting = Setting(
+                        id = "",
+                        key = key.trim(),
+                        value = value.trim(),
+                        description = description.trim(),
+                        clientId = clientId
+                    )
+                    settingsRepository.createSetting(newSetting)
+                }
+
+                is SettingFormMode.Edit -> {
+                    val updatedSetting = mode.setting.copy(
+                        value = value.trim(),
+                        description = description.trim()
+                    )
+                    settingsRepository.updateSetting(updatedSetting)
+                }
+            }
+
+            result
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            showSettingFormDialog = false,
+                            isSubmittingSetting = false
+                        )
+                    }
+                    loadSettings() // Reload settings from repository to ensure sync
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isSubmittingSetting = false,
+                            submitSettingError = error.message
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun showDeleteSettingConfirmation(setting: Setting) {
+        _uiState.update {
+            it.copy(
+                showDeleteSettingConfirmation = true,
+                settingToDelete = setting,
+                deleteSettingError = null
+            )
+        }
+    }
+
+    private fun cancelDeleteSetting() {
+        _uiState.update {
+            it.copy(
+                showDeleteSettingConfirmation = false,
+                settingToDelete = null,
+                deleteSettingError = null
+            )
+        }
+    }
+
+    private fun confirmDeleteSetting() {
+        val setting = _uiState.value.settingToDelete ?: return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDeletingSetting = true, deleteSettingError = null) }
+
+            settingsRepository.deleteSetting(setting.id)
+                .onSuccess {
+                    _uiState.update { state ->
+                        state.copy(
+                            settings = state.settings.filter { it.id != setting.id },
+                            showDeleteSettingConfirmation = false,
+                            settingToDelete = null,
+                            isDeletingSetting = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isDeletingSetting = false,
+                            deleteSettingError = error.message
                         )
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ koin-bom = "4.1.1"
 kotlin = "2.3.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.8.0"
+kotlinx-datetime = "0.6.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -33,6 +34,7 @@ androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 # Koin
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin-bom" }
 koin-core = { module = "io.insert-koin:koin-core" }


### PR DESCRIPTION
- Implement data models and repositories for `Greenhouse`, `Sector`, `Device`, `Alert`, and `Setting` entities.
- Create specific tabs within `ClientDetailScreen` to display tabular data for each entity type (e.g., `ClientDetailGreenhousesTab`, `DevicesTable`).
- Add form dialogs supporting Create/Edit modes and field validation for all five entities.
- Update `ClientDetailViewModel`, `ClientDetailUiState`, and `ClientDetailEvent` to manage CRUD operations, lazy data loading, and dialog states.
- Register new repositories in Koin's `DataModule` and update `PresentationModule` to inject dependencies into the ViewModel.
- Configure `ClientDetailScreen` to render specific dialogs and handle Floating Action Button logic based on the selected tab.
- Add `kotlinx-datetime` dependency for handling alert timestamps.
- Include comprehensive English and Spanish string resources for table headers, form labels, validation errors, and confirmation dialogs.